### PR TITLE
FIX: Now close plot before creating a new one in add_subplots

### DIFF
--- a/act/plotting/plot.py
+++ b/act/plotting/plot.py
@@ -111,6 +111,7 @@ class TimeSeriesDisplay(object):
         """
 
         if self.fig is not None:
+            plt.close(self.fig)
             del self.fig
 
         if len(subplot_shape) == 2:


### PR DESCRIPTION
Not having this line created odd behavior where one blank plot would be made in addition to the plot that was needed when display.add_subplots() was called.