### PR TITLE
ADD: kwargs to read functions, eliminate annoying warning

### DIFF
--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -45,7 +45,7 @@ class ARMStandardsFlag(Flag):
     """The dataset does not have a datastream field."""
 
 
-def read_netcdf(filenames, variables=None):
+def read_netcdf(filenames, variables=None, verbose=False, **kwargs):
 
     """
     Returns `xarray.Dataset` with stored data and metadata from a user-defined
@@ -57,11 +57,15 @@ def read_netcdf(filenames, variables=None):
         Name of file(s) to read
     variables : list, optional
         List of variable name(s) to read
+    verbose: bool
+        If true, will print a statement if the file is not found.
+
+    Additional keywords will be passed into xr.open_mfdataset
 
     Returns
     -------
     act_obj : Object
-        ACT dataset
+        ACT dataset. Will return None if the file is not found.
 
     Examples
     --------
@@ -78,7 +82,8 @@ def read_netcdf(filenames, variables=None):
 
     file_dates = []
     file_times = []
-    arm_ds = xr.open_mfdataset(filenames, parallel=True, concat_dim='time')
+    arm_ds = xr.open_mfdataset(filenames, parallel=True, concat_dim='time',
+                               **kwargs)
 
     # Adding support for wildcards
     if isinstance(filenames, str):
@@ -123,9 +128,6 @@ def check_arm_standards(ds):
     the_flag.NO_DATASTREAM = False
     the_flag.OK = True
     if 'datastream' not in ds.attrs.keys():
-        warnings.warn(("ARM standards require that the datastream name" +
-                       " be defined, currently using a default" +
-                       " of act_datastream."), UserWarning)
         the_flag.OK = False
         the_flag.NO_DATASTREAM = True
 

--- a/act/io/csvfiles.py
+++ b/act/io/csvfiles.py
@@ -11,7 +11,7 @@ import pandas as pd
 from .armfiles import check_arm_standards
 
 
-def read_csv(filename, sep=',', column_names=None, skipfooter=0):
+def read_csv(filename, sep=',', column_names=None, skipfooter=0, **kwargs):
 
     """
     Returns an `xarray.Dataset` with stored data and metadata from user-defined
@@ -20,10 +20,20 @@ def read_csv(filename, sep=',', column_names=None, skipfooter=0):
     ----------
     filenames : str or list
         Name of file(s) to read
+    sep: str
+        The separator between columns in the csv file.
+    column_names: list or None
+        The list of column names in the csv file.
+    verbose: bool
+        If true, will print if a file is not found.
+
+    Additional keyword arguments will be passed into pandas.read_csv.
+
     Returns
     -------
     act_obj : Object
-        ACT dataset
+        ACT dataset. Will be None if the file is not found.
+
     Examples
     --------
     This example will load the example sounding data used for unit testing.
@@ -35,7 +45,7 @@ def read_csv(filename, sep=',', column_names=None, skipfooter=0):
 
     # Read data using pandas read_csv
     arm_ds = pd.read_csv(filename, sep=sep, names=column_names,
-                         skipfooter=skipfooter, engine='python')
+                         skipfooter=skipfooter, engine='python', **kwargs)
 
     # Set Coordinates if there's a variable date_time
     if 'date_time' in arm_ds:


### PR DESCRIPTION
This addresses #36 and eliminates the warning message when a dataset doesn't conform to ARM standards as well as allows keyword arguments for pd.read_csv and xr.open_mfdataset for the read functions.