### PR TITLE
ADD: Minimum python version to docs.

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,12 +2,15 @@
 Installation
 ============
 
-You can build the ARM Community Toolkit from source and install it doing::
+In order to use ACT, you must have Python 3.6+ installed. We do not plan on 
+having support for Python 2.x as it will be deprecated very soon.
+
+You can build the Atmospheric Community Toolkit from source and install it doing::
 
 
     $ git clone https://github.com/ANL-DIGR/ACT
     $ cd ACT
     $ python setup.py install
 
-We soon plan to implement pip install and conda install features.
+We soon plan to implement pip install and conda install features. 
 


### PR DESCRIPTION
We now explictly state that Python 3.6 or greater is needed to run ACT. This takes care of #23.