### PR TITLE
Clean state

### DIFF
--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -26,8 +26,9 @@ class CleanDataset(object):
                    ["See global attributes for individual bit descriptions.",
                     "This field contains bit packed integer values, where "
                     "each bit represents a QC test on the data. Non-zero "
-                    "bits indicate the QC condition given in the description "
-                    "for those bits; a value of 0 (no bits set) indicates "
+                    "bits indicate the QC condition given in the "
+                    "description for those bits; a value of 0 "
+                    "(no bits set) indicates "
                     "the data has not failed any QC tests."
                     ]
                    }
@@ -47,10 +48,10 @@ class CleanDataset(object):
 
     def cleanup(self, cleanup_arm_qc=True, clean_arm_state_vars=None,
                 handle_missing_value=True, link_qc_variables=True,
-                add_source_files=True, **kwargs):
+                **kwargs):
         '''
         Wrapper method to automatically call all the standard methods
-        for obj cleanup. Has options to pass through keywords.
+        for obj cleanup.
 
         Parameters
         ----------
@@ -59,122 +60,106 @@ class CleanDataset(object):
             Default is True
         clean_arm_state_vars : list of str
             Option to clean xarray object state variables from ARM to CF
-            standards.
-            Pass in list of variable names. Default is None.
+            standards. Pass in list of variable names.
         handle_missing_value : bool
-            Option to update and fix missing values. Default is True
+            Go through variables and look for cases where a QC or state varible
+            was convereted to a float and missing values set to np.nan. This
+            is done because of xarry's default to use mask_and_scale=True.
+            This will convert the data type back to integer and replace
+            any instances of np.nan to a missing value indicator (most
+            likely -9999).
         link_qc_variables : bool
             Option to link QC variablers through ancillary_variables if not
-            already set. Default is True
-        add_source_files : bool
-            Option to add global attribute to list files read.
-            Default is True.
+            already set.
+        **kwargs:
+            Keyword arguments passed through to clean.clean_arm_qc
+            method.
 
         '''
 
-        # Clean up ARM QC to be more like CF state fields
+        # Convert ARM QC to be more like CF state fields
         if cleanup_arm_qc:
             self._obj.clean.clean_arm_qc(**kwargs)
 
-        # Clean up ARM state fields to be more liek CF state fields
-        if clean_arm_state_vars:
+        # Convert ARM state fields to be more liek CF state fields
+        if clean_arm_state_vars is not None:
             self._obj.clean.clean_arm_state_variables(clean_arm_state_vars)
 
-        # Correctly clean up missing value indicators
+        # Correctly convert data type because of missing value
+        # indicators in state and QC variables. Needs to be run after
+        # clean.clean_arm_qc to use CF attribute names.
         if handle_missing_value:
-            self._obj.clean.handle_missing_values(**kwargs)
+            self._obj.clean.handle_missing_values()
 
-        # Update to add some ancillary_variables linkages
-        # between variable and QC variable
+        # Add some ancillary_variables linkages
+        # between data variable and QC variable
         if link_qc_variables:
             self._obj.clean.link_variables()
 
-    def handle_missing_values(self, **kwargs):
-        '''Correctly handle missing_value and _FillValue in object.
+    def handle_missing_values(self, default_missing_value=np.int32(-9999)):
+        '''
+        Correctly handle missing_value and _FillValue in object.
+        xarray will automatically replace missing_value and
+        _FillValue in the data with NaN. This is great for data set
+        as type float but not great for int data. Can cause issues
+        with QC and state fields. This will loop through the array
+        looking for state and QC fields and revert them back to int
+        data type if upconverted to float to handle NaNs. Issue is that
+        xarray will convert data type to float if the attribute is defined
+        even if no data are set as missing value.
 
         Parameters
         ----------
-        additional_missing_values : list
-            List of values to also use as missing value indicator. These
-            will be checked and set to the one true missing value.
-
-        Returns
-        -------
-        object : xarray dataset
-            xarray dataset object of read data or None if no data found.
-            If the variable does not have a missing_value or _FillValue
-            will use -9999 set to correct type. Skips ARM QC variables
-            and variables with flag_meanings attributes.
-
-        Todo
-        ----
-            Need to give option of choosing missing_value or _FillValue
-            as the attribute to use. Currently converts everything to
-            missing_value.
+        default_missing_value: numpy data type
+            The data type to set the default missing value if needed unable
+            to determine the correct data type by inspecting the varible
+            data values and flag_masks or flag_values attributes.
 
         '''
 
-        additional_missing_values = None
-        if 'additional_missing_values' in kwargs.keys():
-            additional_missing_values = kwargs[
-                'additional_missing_values=None']
+        state_att_names = ['flag_values', 'flag_meanings',
+                           'flag_masks', 'flag_attributes']
 
-        attr_names = ['missing_value', '_FillValue']
-        default_missing_value = np.int32(-9999)
+        # Look for variables that have 2 of the state_att_names defined
+        # as attribures and is of type float. If so assume the variable
+        # was incorreclty converted to float type.
         for var in self._obj.data_vars:
-            # Skip data quality fields.
-            if('Quality check results on field:' in
-                    self._obj[var].attrs['long_name']):
-                continue
+            var_att_names = self._obj[var].attrs.keys()
+            if (len(set(state_att_names) & set(var_att_names)) >= 2
+                and self._obj[var].values.dtype in
+                    [np.dtype('float16'), np.dtype('float32'),
+                     np.dtype('float64')]):
 
-            # Skip state fields.
-            try:
-                self._obj[var].attrs['flag_meanings']
-                continue
-            except KeyError:
-                pass
-
-            data_type = self._obj[var].values.dtype
-            missing_values = []
-            if additional_missing_values:
-                missing_values = [additional_missing_values]
-            for attr_name in attr_names:
+                # Change any np.nan values to missing value indicator
+                data = self._obj[var].values
+                data[np.isnan(data)] = default_missing_value.astype(data.dtype)
+                # Convert data to match type of flag_mask or flag_values
+                # as the best guess of what type is correct.
                 try:
-                    missing_value = self._obj[var].attrs[attr_name]
-                    if isinstance(missing_value, (list, tuple)):
-                        missing_values.extend(missing_value)
-                    else:
-                        missing_values.append(missing_value)
-                except KeyError:
-                    continue
+                    data = data.astype(
+                        self._obj[var].attrs['flag_masks'][0].dtype)
+                except (KeyError, IndexError):
+                    data = data.astype(
+                        self._obj[var].attrs['flag_values'][0].dtype)
+                except (KeyError, IndexError):
+                    data = data.astype(default_missing_value.dtype)
 
-            if not missing_values:
-                missing_values = [default_missing_value.astype(data_type)]
-
-            try:
-                for ii, missing_value in enumerate(missing_values):
-                    missing_values[ii] = missing_value.astype(data_type)
-
-                if len(missing_values) > 1:
-                    data = self._obj[var].values
-                    for ii, missing_value in enumerate(missing_values):
-                        if ii == 0:
-                            continue
-                        data[data == missing_value] = missing_values[0]
-                    self._obj[var].values = data
-
-                self._obj[var].attrs['missing_value'] = copy.copy(
-                    missing_values[0])
-            except AttributeError:
-                pass
+                # Return data to object and add missing value indicator
+                # attribute to variable.
+                self._obj[var].values = data
+                self._obj[var].attrs['missing_value'] = \
+                    default_missing_value.astype(data.dtype)
 
     def get_attr_info(self, variable=None, flag=False):
-        '''Get QC definitions and return as dictionary.
+        '''
+        Get ARM quality control definitions from the ARM standard
+        bit_#_description attributes and return as dictionary.
 
         Parameters
         ----------
         variable : str
-            Variable name to get attribute information.
+            Variable name to get attribute information. If set to None
+            will get global attributes.
         flag : bool
             Optional flag indicating if QC is expected to be bitpacked
             or integer. Flag = True indicates integer QC. Default
@@ -182,17 +167,44 @@ class CleanDataset(object):
 
         Returns
         -------
-        attributes dictionary : dict
+        attributes dictionary : dict or None
             A dictionary contianing the attribute information converted from
             ARM QC to CF QC. Keys in dict will be set only if values to
             populate. All keys include 'flag_meanings', 'flag_masks',
             'flag_values', 'flag_assessments', 'flag_tests', 'arm_attributes'.
+            Returns None if none found.
 
         '''
 
         string = 'bit'
         if flag:
             string = 'flag'
+        else:
+            found_string = False
+            try:
+                if self._obj.attrs['qc_bit_comment']:
+                    string = 'bit'
+                    found_string = True
+            except KeyError:
+                pass
+
+            if found_string is False:
+                try:
+                    if self._obj.attrs['qc_flag_comment']:
+                        string = 'flag'
+                        found_string = True
+                except KeyError:
+                    pass
+
+            if found_string is False:
+                var = self.matched_qc_variables
+                if len(var) > 0:
+                    try:
+                        flag_method = self._obj[var[0]].attrs['flag_method']
+                        string = flag_method
+                        found_string = True
+                    except KeyError:
+                        pass
 
         try:
             if variable:
@@ -216,62 +228,95 @@ class CleanDataset(object):
         flag_meanings = []
         flag_assessments = []
         arm_attributes = []
+
+        dtype = np.int32
         for att_name in attributes:
-            description = re.match(attr_description_pattern, att_name)
             try:
+                description = re.match(attr_description_pattern, att_name)
                 description_bit_num.append(int(description.groups()[1]))
                 flag_meanings.append(attributes[att_name])
                 arm_attributes.append(att_name)
             except AttributeError:
                 pass
 
-            assessment = re.match(attr_assessment_pattern, att_name)
             try:
+                assessment = re.match(attr_assessment_pattern, att_name)
                 assessment_bit_num.append(int(assessment.groups()[1]))
                 flag_assessments.append(attributes[att_name])
                 arm_attributes.append(att_name)
             except AttributeError:
                 pass
 
+        if variable is not None:
+            # Try and get the data type from the variable if it is an int
+            try:
+                if (self._obj[variable].values.dtype in [
+                        np.dtype('int8'), np.dtype('int16'),
+                        np.dtype('int32'), np.dtype('int64')]):
+                    dtype = self._obj[variable].values.dtype
+            except AttributeError:
+                pass
+
+            # If the data is type float check the largest value and make
+            # sure the type we set can handle it.
+            if np.nanmax(self._obj[variable].values) > 2**32 - 1:
+                dtype = np.int64
+
         # Sort on bit number to ensure correct description order
         index = np.argsort(description_bit_num)
         flag_meanings = np.array(flag_meanings)
         description_bit_num = np.array(description_bit_num)
-        flag_meanings = list(flag_meanings[index])
-        description_bit_num = list(description_bit_num[index])
+        flag_meanings = flag_meanings[index]
+        description_bit_num = description_bit_num[index]
 
         # Sort on bit number to ensure correct assessment order
         index = np.argsort(assessment_bit_num)
         flag_assessments = np.array(flag_assessments)
-        flag_assessments = list(flag_assessments[index])
+        flag_assessments = flag_assessments[index]
 
         # Convert bit number to mask number
-        if description_bit_num:
+        if len(description_bit_num) > 0:
             flag_masks = np.array(description_bit_num)
-            flag_masks = list(np.left_shift(1, flag_masks - 1))
+            flag_masks = np.left_shift(1, flag_masks - 1)
 
         # build dictionary to return values
-        return_dict = dict()
-        if flag_meanings:
-            return_dict['flag_meanings'] = flag_meanings
-        if not flag and flag_masks:
-            return_dict['flag_masks'] = flag_masks
-        if flag and flag_masks:
-            return_dict['flag_values'] = description_bit_num
-        if flag_assessments:
-            return_dict['flag_assessments'] = flag_assessments
-        if description_bit_num:
-            return_dict['flag_tests'] = description_bit_num
-        if arm_attributes:
+        if len(flag_masks) > 0 or len(description_bit_num) > 0:
+            return_dict = dict()
+            return_dict['flag_meanings'] = np.array(flag_meanings,
+                                                    dtype=np.str)
+            if len(flag_masks) > 0 and max(flag_masks) > 2**32 - 1:
+                flag_mask_dtype = np.int64
+            else:
+                flag_mask_dtype = dtype
+
+            if flag:
+                return_dict['flag_values'] = np.array(description_bit_num,
+                                                      dtype=dtype)
+                return_dict['flag_masks'] = np.array([],
+                                                     dtype=flag_mask_dtype)
+            else:
+                return_dict['flag_values'] = np.array([],
+                                                      dtype=dtype)
+                return_dict['flag_masks'] = np.array(flag_masks,
+                                                     dtype=flag_mask_dtype)
+
+            return_dict['flag_assessments'] = np.array(flag_assessments,
+                                                       dtype=np.str)
+            return_dict['flag_tests'] = np.array(description_bit_num,
+                                                 dtype=dtype)
             return_dict['arm_attributes'] = arm_attributes
 
-        # if nothing to return set to None
-        if not return_dict:
+        else:
+            # If nothing to return set to None
             return_dict = None
 
         return return_dict
 
-    def clean_arm_state_variables(self, variables, **kwargs):
+    def clean_arm_state_variables(self,
+                                  variables,
+                                  override_cf_flag=True,
+                                  clean_units_string=True,
+                                  integer_flag=True):
         '''
         Function to clean up state variables to use more CF method.
 
@@ -279,7 +324,6 @@ class CleanDataset(object):
         ----------
         variables : list of str
             List of variable names to update.
-
         override_cf_flag : bool
             Option to overwrite CF flag_meanings attribute if it exists
             with the values from ARM QC bit_#_description. Default is True.
@@ -291,37 +335,24 @@ class CleanDataset(object):
 
         '''
 
-        override_cf_flag = True
-        if 'override_cf_flag' in kwargs.keys():
-            override_cf_flag = kwargs['override_cf_flag']
-
-        clean_units_string = True
-        if 'clean_units_string' in kwargs.keys():
-            clean_units_string = kwargs['clean_units_string']
-
-        integer_flag = True
-        if 'integer_flag' in kwargs.keys():
-            integer_flag = kwargs['integer_flag']
-
         if isinstance(variables, str):
-            variables = [copy.copy(variables)]
+            variables = [variables]
 
         for var in variables:
             flag_info = self.get_attr_info(variable=var, flag=integer_flag)
-            if not flag_info:
+            if flag_info is not None:
                 return
 
             # Add new attributes to variable
             for attr in ['flag_values', 'flag_meanings', 'flag_masks']:
-                attr_exists = attr in self._obj[var].attrs.keys()
 
-                try:
-                    if not attr_exists:
+                if len(flag_info[attr]) > 0:
+                    # Only add if attribute does not exist.
+                    if attr in self._obj[var].attrs.keys() is False:
                         self._obj[var].attrs[attr] = flag_info[attr]
+                    # If flag is set set attribure even if exists
                     elif override_cf_flag:
                         self._obj[var].attrs[attr] = flag_info[attr]
-                except KeyError:
-                    pass
 
             # Remove replaced attributes
             arm_attributes = flag_info['arm_attributes']
@@ -337,9 +368,16 @@ class CleanDataset(object):
                 self._obj[var].attrs['units'] = '1'
 
     def correct_valid_minmax(self, qc_variable):
-        '''Function to correct the name and location of
-           QC limit variables that use
-           valid_min and valid_max incorrectly.
+        '''
+        Function to correct the name and location of
+        quality control limit variables that use
+        valid_min and valid_max incorrectly.
+
+        Parameters
+        ----------
+        qc_varialbe: str
+            Name of quality control variable in xarray object to correct.
+
         '''
 
         test_dict = {'valid_min': 'fail_min',
@@ -372,8 +410,10 @@ class CleanDataset(object):
             self._obj[qc_variable].attrs['flag_meanings'] = flag_meanings
 
     def link_variables(self):
-        '''Add some attributes to link and explain data
-           to QC data relationship.'''
+        '''
+        Add some attributes to link and explain data
+        to QC data relationship.
+        '''
 
         for var in self._obj.data_vars:
             aa = re.match(r"^qc_(.+)", var)
@@ -418,111 +458,14 @@ class CleanDataset(object):
             self._obj[qc_variable].attrs['standard_name']\
                 = qc_var_standard_name
 
-    def get_qc_attr_info(self, variable=None, flag=False):
-        '''
-        Get QC definitions and return as dictionary.
+    def clean_arm_qc(self,
+                     override_cf_flag=True,
+                     clean_units_string=True,
+                     correct_valid_min_max=True):
+        """
+        Function to clean up xarray object QC variables.
 
-        Parameters
-        ----------
-        variable : str
-            Variable name to return QC attribute information. Default is None
-            which returns global attribute QC information.
-        flag : bool
-            Option to indicate type of QC, bitpacked or integer. Flag set to
-            True indicates integer. Default is False or bitpacked.
-
-        Todo
-        ----
-            Need to update to handle bitpacked vs. integer automatically.
-
-        '''
-
-        string = 'bit'
-        if flag:
-            string = 'flag'
-
-        try:
-            if variable:
-                attr_description_pattern = (r"(^" + string +
-                                            r")_([0-9])_(description$)")
-                attr_assessment_pattern = (r"(^" + string +
-                                           r")_([0-9])_(assessment$)")
-                attributes = self._obj[variable].attrs
-            else:
-                attr_description_pattern = (r"(^qc_" + string +
-                                            r")_([0-9])_(description$)")
-                attr_assessment_pattern = (r"(^qc_" + string +
-                                           r")_([0-9])_(assessment$)")
-                attributes = self._obj.attrs
-        except KeyError:
-            return None
-
-        assessment_bit_num = []
-        description_bit_num = []
-        flag_masks = []
-        flag_meanings = []
-        flag_assessments = []
-        arm_attributes = []
-        for att_name in attributes:
-            description = re.match(attr_description_pattern, att_name)
-            try:
-                description_bit_num.append(int(description.groups()[1]))
-                flag_meanings.append(attributes[att_name])
-                arm_attributes.append(att_name)
-            except AttributeError:
-                pass
-
-            assessment = re.match(attr_assessment_pattern, att_name)
-            try:
-                assessment_bit_num.append(int(assessment.groups()[1]))
-                flag_assessments.append(attributes[att_name])
-                arm_attributes.append(att_name)
-            except AttributeError:
-                pass
-
-        # Sort on bit number to ensure correct description order
-        index = np.argsort(description_bit_num)
-        flag_meanings = np.array(flag_meanings)
-        description_bit_num = np.array(description_bit_num)
-        flag_meanings = list(flag_meanings[index])
-        description_bit_num = list(description_bit_num[index])
-
-        # Sort on bit number to ensure correct assessment order
-        if len(flag_assessments) > 0:
-            index = np.argsort(assessment_bit_num)
-            flag_assessments = np.array(flag_assessments)
-            flag_assessments = list(flag_assessments[index])
-        else:
-            flag_assessments = ['Unknown'] * len(flag_meanings)
-
-        # Convert bit number to mask number
-        if description_bit_num:
-            flag_masks = np.array(description_bit_num)
-            flag_masks = list(np.left_shift(1, flag_masks - 1))
-
-        # build dictionary to return values
-        return_dict = dict()
-        if flag_meanings:
-            return_dict['flag_meanings'] = flag_meanings
-        if not flag and flag_masks:
-            return_dict['flag_masks'] = flag_masks
-        if flag and flag_masks:
-            return_dict['flag_values'] = description_bit_num
-        if flag_assessments:
-            return_dict['flag_assessments'] = flag_assessments
-        if description_bit_num:
-            return_dict['flag_tests'] = description_bit_num
-        if arm_attributes:
-            return_dict['arm_attributes'] = arm_attributes
-
-        # if nothing to return set to None
-        if not return_dict:
-            return_dict = None
-
-        return return_dict
-
-    def clean_arm_qc(self, **kwargs):
-        """Function to clean up xarray object QC variables.
+        ...
 
         Parameters
         ----------
@@ -540,50 +483,29 @@ class CleanDataset(object):
             assume is being used correctly. Default is True.
         """
 
-        override_cf_flag = True
-        if 'override_cf_flag' in kwargs.keys():
-            override_cf_flag = kwargs['override_cf_flag']
-
-        clean_units_string = True
-        if 'clean_units_string' in kwargs.keys():
-            clean_units_string = kwargs['clean_units_string']
-
-        correct_valid_min_max = True
-        if 'correct_valid_min_max' in kwargs.keys():
-            correct_valid_min_max = kwargs['correct_valid_min_max']
-
-        global_qc = self.get_qc_attr_info()
-
-        var_num = -1
+        global_qc = self.get_attr_info()
         for qc_var in self.matched_qc_variables:
-            var_num += 1
-            # if first pass try to clean up global attributes
-            if var_num == 0 and global_qc is not None:
-                global_attributes = global_qc['arm_attributes']
-                global_attributes.extend(['qc_bit_comment'])
-                for attr in global_attributes:
-                    try:
-                        del self._obj.attrs[attr]
-                    except KeyError:
-                        pass
 
             # Clean up units attribute from unitless to udunits '1'
             if (clean_units_string and
                     self._obj[qc_var].attrs['units'] == 'unitless'):
                 self._obj[qc_var].attrs['units'] = '1'
 
-            qc_attributes = self.get_qc_attr_info(variable=qc_var)
-            if not qc_attributes:
+            qc_attributes = self.get_attr_info(variable=qc_var)
+            if qc_attributes is None:
                 qc_attributes = global_qc
 
             # Add new attributes to variable
-            for attr in ['flag_masks', 'flag_meanings', 'flag_assessments']:
-                attr_exists = attr in self._obj[qc_var].attrs.keys()
+            for attr in ['flag_masks', 'flag_meanings',
+                         'flag_assessments', 'flag_values']:
 
-                if not attr_exists:
-                    self._obj[qc_var].attrs[attr] = qc_attributes[attr]
-                elif override_cf_flag:
-                    self._obj[qc_var].attrs[attr] = qc_attributes[attr]
+                if len(qc_attributes[attr]) > 0:
+                    # Only add if attribute does not exists
+                    if attr in self._obj[qc_var].attrs.keys() is False:
+                        self._obj[qc_var].attrs[attr] = qc_attributes[attr]
+                    # If flag is set add attribure even if already exists
+                    elif override_cf_flag:
+                        self._obj[qc_var].attrs[attr] = qc_attributes[attr]
 
             # Remove replaced attributes
             arm_attributes = qc_attributes['arm_attributes']
@@ -597,3 +519,12 @@ class CleanDataset(object):
             # Check for use of valid_min and valid_max as QC limits and fix
             if correct_valid_min_max:
                 self._obj.clean.correct_valid_minmax(qc_var)
+
+        # Clean up global attributes
+        global_attributes = global_qc['arm_attributes']
+        global_attributes.extend(['qc_bit_comment'])
+        for attr in global_attributes:
+            try:
+                del self._obj.attrs[attr]
+            except KeyError:
+                pass

--- a/act/tests/test_clean.py
+++ b/act/tests/test_clean.py
@@ -1,4 +1,5 @@
 import act
+import numpy as np
 
 
 def test_clean():
@@ -25,15 +26,20 @@ def test_clean():
     assert 'flag_assessments' in ceil_ds['qc_first_cbh'].attrs.keys()
 
     # Check the value of flag_assessments is as expected
-    assert (ceil_ds['qc_first_cbh'].attrs['flag_assessments'] ==
-            ['Bad', 'Bad', 'Bad'])
+    assert (all([ii == 'Bad' for ii in
+            ceil_ds['qc_first_cbh'].attrs['flag_assessments']]))
+
+    # Check the type is correct
+    assert (type(ceil_ds['qc_first_cbh'].attrs['flag_masks'])) == np.ndarray
 
     # Check that ancillary varibles is being added
-    assert 'qc_first_cbh' in ceil_ds['first_cbh'].attrs['ancillary_variables'].split()
+    assert ('qc_first_cbh' in
+            ceil_ds['first_cbh'].attrs['ancillary_variables'].split())
 
     # Check that state field is updated to CF
     assert 'flag_values' in ceil_ds['detection_status'].attrs.keys()
     assert 'flag_meanings' in ceil_ds['detection_status'].attrs.keys()
-    assert 'detection_status' in ceil_ds['first_cbh'].attrs['ancillary_variables'].split()
+    assert ('detection_status' in
+            ceil_ds['first_cbh'].attrs['ancillary_variables'].split())
 
     ceil_ds.close()


### PR DESCRIPTION
This is an update to help fix issues with xarray converting any variable with _FillValue or missing_value attribute set.  If xarray finds a variable like this it will convert the variable to float and change any missing value indicator to nan. This is fine for data but not good for qc or state fields.

I also updated some of the other functions as there were some minor issues and duplication.