### PR TITLE
STY: Multiple style changes, mispelling, imports and more.

### DIFF
--- a/act/corrections/__init__.py
+++ b/act/corrections/__init__.py
@@ -12,6 +12,7 @@ The procedures in this module contain corrections for various ARM datasets.
 
     ceil.correct_ceil
 """
+
 from . import common
 from . import ceil
 from . import mpl

--- a/act/corrections/ceil.py
+++ b/act/corrections/ceil.py
@@ -3,24 +3,24 @@ import numpy as np
 
 def correct_ceil(obj, fill_value=1e-7):
     """
-    This procedure corrects celiometer data by filling all zero and
+    This procedure corrects ceilometer data by filling all zero and
     negative values of backscatter with fill_value and then converting
     the backscatter data into logarithmic space.
 
     Parameters
     ----------
-    obj: Dataset object
-        The ceiliometer dataset to correct. The backscatter data should be
+    obj : Dataset object
+        The ceilometer dataset to correct. The backscatter data should be
         in linear space.
-    fill_value: float
+    fill_value : float
         The fill_value to use. The fill_value is entered in linear space.
 
     Returns
     -------
-    obj: Dataset object
-        The celiometer dataset containing the corrected values.
-    """
+    obj : Dataset object
+        The ceilometer dataset containing the corrected values.
 
+    """
     backscat = obj['backscatter'].data
     backscat[backscat <= 0] = fill_value
     backscat = np.log10(backscat)

--- a/act/corrections/mpl.py
+++ b/act/corrections/mpl.py
@@ -5,30 +5,30 @@ import warnings
 
 def correct_mpl(obj):
     """
-    This procedure corrects MPL data
-    1.) Throw out data before laser firing (heights < 0)
-    2.) Remove background signal
+    This procedure corrects MPL data:
+    1.) Throw out data before laser firing (heights < 0).
+    2.) Remove background signal.
     3.) Afterpulse Correction - Subtraction of (afterpulse-darkcount).
         NOTE: Currently the Darkcount in VAPS is being calculated as
         the afterpulse at ~30km. But that might not be absolutely
         correct and we will likely start providing darkcount profiles
         ourselves along with other corrections.
-    4.) Range Correction
-    5.) Overlap Correction (Multiply)
+    4.) Range Correction.
+    5.) Overlap Correction (Multiply).
 
-    Note: Deadtime and darkcount corrections are not being applied yet
+    Note: Deadtime and darkcount corrections are not being applied yet.
 
     Parameters
     ----------
-    obj: Dataset object
+    obj : Dataset object
         The ACT object.
 
     Returns
     -------
-    obj: Dataset object
+    obj : Dataset object
         The ACT Object containing the corrected values.
-    """
 
+    """
     # Get some variables before processing begins
     act = obj.act
 

--- a/act/discovery/__init__.py
+++ b/act/discovery/__init__.py
@@ -6,11 +6,12 @@ act.discovery (act.discovery)
 .. currentmodule:: act.discovery
 
 This module contains procedures for exploring and downloading data on
-ARM Data Discovery
+ARM Data Discovery.
 
 .. autosummary::
     :toctree: generated/
 
     download_data
 """
+
 from .get_armfiles import download_data

--- a/act/discovery/get_armfiles.py
+++ b/act/discovery/get_armfiles.py
@@ -17,24 +17,23 @@ def download_data(username, token, datastream,
 
     Parameters
     ----------
-    username: str
+    username : str
         The username to use for logging into the ADC archive.
-    token: str
+    token : str
         The access token for accessing the ADC archive.
-    datastream: str
-        The name of the datastream to acquire
-    startdate: str
+    datastream : str
+        The name of the datastream to acquire.
+    startdate : str
         The start date of the data to acquire. Format is YYYY-MM-DD.
-    enddate: str
+    enddate : str
         The end date of the data to acquire. Format is YYYY-MM-DD.
-    output: str
+    output : str
         The output directory for the data. Set to None to make a folder in the
         current working directory with the same name as *datastream* to place
         the files in.
 
     Notes
     -----
-
     This programmatic interface allows users to query and automate
     machine-to-machine downloads of ARM data. This tool uses a REST URL and
     specific parameters (saveData, query), user ID and access token, a
@@ -69,8 +68,8 @@ def download_data(username, token, datastream,
 
         act.discovery.download_data('userName','XXXXXXXXXXXXXXXX', 'sgpmetE13.b1',
                                     '2017-01-14', '2017-01-20')
-    """
 
+    """
     # default start and end are empty
     start, end = '', ''
     # start and end strings for query_url are constructed

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -24,9 +24,9 @@ class ARMStandardsFlag(Flag):
 
     Attributes
     ----------
-    OK:
-        This flag is set if the dataset conforms to ARM standards
-    NO_DATASTREAM:
+    OK : flag
+        This flag is set if the dataset conforms to ARM standards.
+    NO_DATASTREAM : flag
         This flag is set if the dataset does not have a datastream
         field.
 
@@ -37,12 +37,12 @@ class ARMStandardsFlag(Flag):
          my_flag = act.io.armfiles.ARMStandardsFlag(
              act.io.armfiles.ARMStandardsFlag.OK)
          assert my_flag.OK
-    """
 
+    """
     OK = auto()
-    """The dataset conforms to ARM standards."""
+    """ The dataset conforms to ARM standards. """
     NO_DATASTREAM = auto()
-    """The dataset does not have a datastream field."""
+    """ The dataset does not have a datastream field. """
 
 
 def read_netcdf(filenames, concat_dim='time', return_None=False, **kwargs):
@@ -53,19 +53,19 @@ def read_netcdf(filenames, concat_dim='time', return_None=False, **kwargs):
     Parameters
     ----------
     filenames : str or list
-        Name of file(s) to read
+        Name of file(s) to read.
     concat_dim : str
         Dimension to concatenate files along. Default value is 'time.'
     return_none : bool, optional
         Catch IOError exception when file not found and return None.
         Default is False.
-    **kwargs  : keywords
-        Keywords to pass through to xarray.open_mfdataset()
+    **kwargs : keywords
+        Keywords to pass through to xarray.open_mfdataset().
 
     Returns
     -------
     act_obj : Object (or None)
-        ACT dataset (or None if no data file(s) found)
+        ACT dataset (or None if no data file(s) found).
 
     Examples
     --------
@@ -78,8 +78,8 @@ def read_netcdf(filenames, concat_dim='time', return_None=False, **kwargs):
         the_ds, the_flag = act.io.armfiles.read_netcdf(
             act.tests.sample_files.EXAMPLE_SONDE_WILDCARD)
         print(the_ds.act.datastream)
-    """
 
+    """
     file_dates = []
     file_times = []
 
@@ -132,16 +132,16 @@ def check_arm_standards(ds):
 
     Parameters
     ----------
-    ds: xarray dataset
+    ds : xarray dataset
         The dataset to check.
 
     Returns
     -------
-    flag: ARMStandardsFlag
+    flag : ARMStandardsFlag
         The flag corresponding to whether or not the file conforms
         to ARM standards.
-    """
 
+    """
     the_flag = ARMStandardsFlag(ARMStandardsFlag.OK)
     the_flag.NO_DATASTREAM = False
     the_flag.OK = True

--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -11,14 +11,15 @@ class CleanDataset(object):
 
     @property
     def matched_qc_variables(self):
-        '''Find variables that are QC variables and return list of names.
+        """
+        Find variables that are QC variables and return list of names.
 
         Returns
         -------
-        variables: list of str
+        variables : list of str
             A list of strings containing the name of each variable.
-        '''
 
+        """
         variables = []
 
         # Will need to find all historical cases and add to list
@@ -49,15 +50,15 @@ class CleanDataset(object):
     def cleanup(self, cleanup_arm_qc=True, clean_arm_state_vars=None,
                 handle_missing_value=True, link_qc_variables=True,
                 **kwargs):
-        '''
+        """
         Wrapper method to automatically call all the standard methods
         for obj cleanup.
 
         Parameters
         ----------
         cleanup_arm_qc : bool
-            Option to clean xarray object from ARM QC to CF QC standards
-            Default is True
+            Option to clean xarray object from ARM QC to CF QC standards.
+            Default is True.
         clean_arm_state_vars : list of str
             Option to clean xarray object state variables from ARM to CF
             standards. Pass in list of variable names.
@@ -71,12 +72,11 @@ class CleanDataset(object):
         link_qc_variables : bool
             Option to link QC variablers through ancillary_variables if not
             already set.
-        **kwargs:
+        **kwargs : keywords
             Keyword arguments passed through to clean.clean_arm_qc
             method.
 
-        '''
-
+        """
         # Convert ARM QC to be more like CF state fields
         if cleanup_arm_qc:
             self._obj.clean.clean_arm_qc(**kwargs)
@@ -97,7 +97,7 @@ class CleanDataset(object):
             self._obj.clean.link_variables()
 
     def handle_missing_values(self, default_missing_value=np.int32(-9999)):
-        '''
+        """
         Correctly handle missing_value and _FillValue in object.
         xarray will automatically replace missing_value and
         _FillValue in the data with NaN. This is great for data set
@@ -112,12 +112,11 @@ class CleanDataset(object):
 
         Parameters
         ----------
-        default_missing_value: numpy int or float
+        default_missing_value : numpy int or float
            The default missing value to use if a missing_value attribute
            is not defined but one is needed.
 
-        '''
-
+        """
         state_att_names = ['flag_values', 'flag_meanings',
                            'flag_masks', 'flag_attributes']
 
@@ -153,7 +152,7 @@ class CleanDataset(object):
                     default_missing_value.astype(data.dtype)
 
     def get_attr_info(self, variable=None, flag=False):
-        '''
+        """
         Get ARM quality control definitions from the ARM standard
         bit_#_description, ... attributes and return as dictionary.
         Will attempt to guess if the flag is integer or bit packed
@@ -177,8 +176,7 @@ class CleanDataset(object):
             'flag_values', 'flag_assessments', 'flag_tests', 'arm_attributes'.
             Returns None if none found.
 
-        '''
-
+        """
         string = 'bit'
         if flag:
             string = 'flag'
@@ -320,7 +318,7 @@ class CleanDataset(object):
                                   override_cf_flag=True,
                                   clean_units_string=True,
                                   integer_flag=True):
-        '''
+        """
         Function to clean up state variables to use more CF style.
 
         Parameters
@@ -334,10 +332,9 @@ class CleanDataset(object):
             Option to update units string if set to 'unitless' to be
             udunits compliant '1'.
         integer_flag : bool
-            Passthrogh keyword of 'flag' for get_attr_info()
+            Pass through keyword of 'flag' for get_attr_info().
 
-        '''
-
+        """
         if isinstance(variables, str):
             variables = [variables]
 
@@ -371,18 +368,16 @@ class CleanDataset(object):
                 self._obj[var].attrs['units'] = '1'
 
     def correct_valid_minmax(self, qc_variable):
-        '''
-        Function to correct the name and location of
-        quality control limit variables that use
-        valid_min and valid_max incorrectly.
+        """
+        Function to correct the name and location of quality control limit
+        variables that use valid_min and valid_max incorrectly.
 
         Parameters
         ----------
-        qc_varialbe: str
+        qc_variable : str
             Name of quality control variable in xarray object to correct.
 
-        '''
-
+        """
         test_dict = {'valid_min': 'fail_min',
                      'valid_max': 'fail_max',
                      'valid_delta': 'fail_delta'}
@@ -413,13 +408,12 @@ class CleanDataset(object):
             self._obj[qc_variable].attrs['flag_meanings'] = flag_meanings
 
     def link_variables(self):
-        '''
+        """
         Add some attributes to link and explain data
         to QC data relationship. Will use non-CF standard_name
         of quality_flag. Hopefully this will be added to the
         standard_name table in the future.
-        '''
-
+        """
         for var in self._obj.data_vars:
             aa = re.match(r"^qc_(.+)", var)
             try:
@@ -470,8 +464,6 @@ class CleanDataset(object):
         """
         Function to clean up xarray object QC variables.
 
-        ...
-
         Parameters
         ----------
         override_cf_flag : bool
@@ -486,8 +478,8 @@ class CleanDataset(object):
             fail_max and fail_detla if the valid_min, valid_max or valid_delta
             is listed in bit discription attribute. If not listed as
             used with QC will assume is being used correctly.
-        """
 
+        """
         global_qc = self.get_attr_info()
         for qc_var in self.matched_qc_variables:
 

--- a/act/io/csvfiles.py
+++ b/act/io/csvfiles.py
@@ -2,7 +2,7 @@
 ===============
 act.io.csvfiles
 ===============
-This module contains I/O operations for loading csv files
+This module contains I/O operations for loading csv files.
 """
 
 # import standard modules
@@ -11,7 +11,8 @@ import pandas as pd
 from .armfiles import check_arm_standards
 
 
-def read_csv(filename, sep=',', engine='python', column_names=None, skipfooter=0, **kwargs):
+def read_csv(filename, sep=',', engine='python', column_names=None,
+             skipfooter=0, **kwargs):
 
     """
     Returns an `xarray.Dataset` with stored data and metadata from user-defined
@@ -19,20 +20,20 @@ def read_csv(filename, sep=',', engine='python', column_names=None, skipfooter=0
 
     Parameters
     ----------
-    filenames: str or list
-        Name of file(s) to read
-    sep: str
+    filenames : str or list
+        Name of file(s) to read.
+    sep : str
         The separator between columns in the csv file.
-    column_names: list or None
+    column_names : list or None
         The list of column names in the csv file.
-    verbose: bool
+    verbose : bool
         If true, will print if a file is not found.
 
     Additional keyword arguments will be passed into pandas.read_csv.
 
     Returns
     -------
-    act_obj: Object
+    act_obj : Object
         ACT dataset. Will be None if the file is not found.
 
     Examples
@@ -44,8 +45,8 @@ def read_csv(filename, sep=',', engine='python', column_names=None, skipfooter=0
         import act
         the_ds, the_flag = act.io.csvfiles.read(
             act.tests.sample_files.EXAMPLE_CSV_WILDCARD)
-    """
 
+    """
     # Read data using pandas read_csv
     arm_ds = pd.read_csv(filename, sep=sep, names=column_names,
                          skipfooter=skipfooter, engine=engine, **kwargs)

--- a/act/io/dataset.py
+++ b/act/io/dataset.py
@@ -13,17 +13,18 @@ class ACTAccessor(object):
 
     Attributes
     ----------
-    file_times: list of datetimes
+    file_times : list of datetimes
         The list of times corresponding to each file in the dataset.
-    file_dates: list of datetimes
+    file_dates : list of datetimes
         The list of dates corresponding to each file in the dataset.
-    datastream: str
+    datastream : str
         The name of the datastream.
-    site: str
-        A string describing the name of the site
-    arm_standards_flag: ARMStandardsFlag
+    site : str
+        A string describing the name of the site.
+    arm_standards_flag : ARMStandardsFlag
         An ARMStandardsFlag showing whether the dataset conforms to ARM
         standards. Will be None for datasets read by a generic reader.
+
     """
     def __init__(self, xarray_obj):
         self._obj = xarray_obj

--- a/act/plotting/GeoDisplay.py
+++ b/act/plotting/GeoDisplay.py
@@ -37,7 +37,6 @@ class GeographicPlotDisplay(Display):
     Examples
     --------
 
-
     """
     def __init__(self, obj, ds_name=None, **kwargs):
         if not CARTOPY_AVAILABLE:
@@ -60,40 +59,40 @@ class GeographicPlotDisplay(Display):
 
         Parameters
         ----------
-        data_field: str
+        data_field : str
             Name of data filed in object to plot.
-        lat_field: str
+        lat_field : str
             Name of latitude field in object to use.
-        lon_field: str
+        lon_field : str
             Name of longitude field in object to use.
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot. Set to None to make ACT
             attempt to automatically determine this.
-        cbar_label: str
+        cbar_label : str
             Label to use with colorbar. If set to None will attempt
             to create label from long_name and units.
-        title: str
+        title : str
             Plot title.
-        projection: str
+        projection : str
             Project to use on plot.
-        plot_buffer: float
+        plot_buffer : float
             Buffer to add around data on plot in lat and lon dimension
-        stamen: str
+        stamen : str
             Dataset to use for background image. Set to None to not use
             background image.
-        tile: int
+        tile : int
             Tile zoom to use with background image. Higer number indicates
             more resolution. A value of 8 is typical for a normal sonde plot.
-        cartopy_feature: list of str or str
+        cartopy_feature : list of str or str
             Cartopy feature to add to plot.
-        cmap: str
+        cmap : str
             Color map to use for colorbar.
-        text: dictionary
+        text : dictionary
             Dictionary of {text:[lon,lat]} to add to plot. Can have more
             than one set of text to add.
-        gridlines: boolean
+        gridlines : boolean
             Use latitude and longitude gridlines.
-        **kwargs: keyword arguments
+        **kwargs : keyword arguments
             Any other keyword arguments that will be passed
             into :func:`matplotlib.pyplot.scatter` when the figure
             is made. See the matplotlib

--- a/act/plotting/GeoDisplay.py
+++ b/act/plotting/GeoDisplay.py
@@ -27,7 +27,7 @@ class GeographicPlotDisplay(Display):
     This is inherited from the :func:`act.plotting.Display`
     class and has therefore has the same attributes as that class.
     See :func:`act.plotting.Display`
-    for more information.  There are no additional attributes or parameters
+    for more information. There are no additional attributes or parameters
     to this class.
 
     In order to create geographic plots, ACT needs the Cartopy package to be
@@ -73,7 +73,7 @@ class GeographicPlotDisplay(Display):
             Label to use with colorbar. If set to None will attempt
             to create label from long_name and units.
         title: str
-            Plot title
+            Plot title.
         projection: str
             Project to use on plot.
         plot_buffer: float
@@ -99,11 +99,12 @@ class GeographicPlotDisplay(Display):
             is made. See the matplotlib
             documentation for further details on what keyword
             arguments are available.
+
         """
         # Get current plotting figure
-#        del self.axes
-#        if self.fig is None:
-#            self.fig = plt.figure()
+        # del self.axes
+        # if self.fig is None:
+        #     self.fig = plt.figure()
 
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "

--- a/act/plotting/SkewTDisplay.py
+++ b/act/plotting/SkewTDisplay.py
@@ -36,7 +36,7 @@ class SkewTDisplay(Display):
     This is inherited from the :func:`act.plotting.Display`
     class and has therefore has the same attributes as that class.
     See :func:`act.plotting.Display`
-    for more information.  There are no additional attributes or parameters
+    for more information. There are no additional attributes or parameters
     to this class.
 
     In order to create Skew-T plots, ACT needs the MetPy package to be
@@ -88,6 +88,7 @@ class SkewTDisplay(Display):
             property is None. See the matplotlib
             documentation for further details on what keyword
             arguments are available.
+
         """
         del self.axes
         if self.fig is None:
@@ -178,7 +179,7 @@ class SkewTDisplay(Display):
         t_field: str
             The name of the field containing the atmospheric temperature.
         td_field: str
-            The name of the field containing the dewpoint
+            The name of the field containing the dewpoint.
         dsname: str or None
             The name of the datastream to plot. Set to None to make ACT
             attempt to automatically determine this.
@@ -190,6 +191,7 @@ class SkewTDisplay(Display):
         -------
         ax: matplotlib axis handle
             The matplotlib axis handle corresponding to the plot.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "
@@ -264,6 +266,7 @@ class SkewTDisplay(Display):
         -------
         ax: matplotlib axis handle
             The axis handle to the plot.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "

--- a/act/plotting/SkewTDisplay.py
+++ b/act/plotting/SkewTDisplay.py
@@ -77,11 +77,11 @@ class SkewTDisplay(Display):
 
         Parameters
         ----------
-        subplot_shape: 1 or 2D tuple, list, or array
+        subplot_shape : 1 or 2D tuple, list, or array
             The structure of the subplots in (rows, cols).
-        subplot_kw: dict, optional
+        subplot_kw : dict, optional
             The kwargs to pass into fig.subplots.
-        **kwargs: keyword arguments
+        **kwargs : keyword arguments
             Any other keyword arguments that will be passed
             into :func:`matplotlib.pyplot.figure` when the figure
             is made. The figure is only made if the *fig*
@@ -117,9 +117,9 @@ class SkewTDisplay(Display):
 
         Parameters
         ----------
-        xrng: 2 number array
+        xrng : 2 number array
             The x limits of the plot.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         """
@@ -140,9 +140,9 @@ class SkewTDisplay(Display):
 
         Parameters
         ----------
-        yrng: 2 number array
+        yrng : 2 number array
             The y limits of the plot.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         """
@@ -169,27 +169,27 @@ class SkewTDisplay(Display):
 
         Parameters
         ----------
-        spd_field: str
+        spd_field : str
             The name of the field corresponding to the wind speed.
-        dir_field: str
+        dir_field : str
             The name of the field corresponding to the wind direction
             in degrees from North.
-        p_field: str
+        p_field : str
             The name of the field containing the atmospheric pressure.
-        t_field: str
+        t_field : str
             The name of the field containing the atmospheric temperature.
-        td_field: str
+        td_field : str
             The name of the field containing the dewpoint.
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot. Set to None to make ACT
             attempt to automatically determine this.
-        kwargs: dict
+        kwargs : dict
             Additional keyword arguments will be passed into
             :func:`act.plotting.SkewTDisplay.plot_from_u_and_v`
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The matplotlib axis handle corresponding to the plot.
 
         """
@@ -225,46 +225,46 @@ class SkewTDisplay(Display):
 
         Parameters
         ----------
-        u_field: str
+        u_field : str
             The name of the field containing the u component of the wind.
-        v_field: str
+        v_field : str
             The name of the field containing the v component of the wind.
-        p_field: str
+        p_field : str
             The name of the field containing the pressure.
-        t_field: str
+        t_field : str
             The name of the field containing the temperature.
-        td_field: str
+        td_field : str
             The name of the field containing the dewpoint temperature.
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot. Set to None to make ACT
             attempt to automatically determine this.
-        subplot_index: tuple
+        subplot_index : tuple
             The index of the subplot to make the plot on.
-        p_levels_to_plot: 1D array
+        p_levels_to_plot : 1D array
             The pressure levels to plot the wind barbs on. Set to None
             to have ACT to use neatly spaced defaults of
             50, 100, 200, 300, 400, 500, 600, 700, 750, 800,
             850, 900, 950, and 1000 hPa.
-        show_parcel: bool
+        show_parcel : bool
             Set to True to show the temperature of a parcel lifted
             from the surface.
-        shade_cape: bool
+        shade_cape : bool
             Set to True to shade the CAPE red.
-        shade_cin: bool
+        shade_cin : bool
             Set to True to shade the CIN blue.
-        set_title: None or str
+        set_title : None or str
             The title of the plot is set to this. Set to None to use
             a default title.
-        plot_barbs_kwargs: dict
+        plot_barbs_kwargs : dict
             Additional keyword arguments to pass into MetPy's
             SkewT.plot_barbs.
-        plot_kwargs: dict
+        plot_kwargs : dict
             Additional keyword arguments to pass into MetPy's
             SkewT.plot.
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The axis handle to the plot.
 
         """

--- a/act/plotting/TimeSeriesDisplay.py
+++ b/act/plotting/TimeSeriesDisplay.py
@@ -50,20 +50,19 @@ class TimeSeriesDisplay(Display):
 
     def day_night_background(self, dsname=None, subplot_index=(0, )):
         """
-        Colorcodes the background according to sunrise/sunset
+        Colorcodes the background according to sunrise/sunset.
 
         Parameters
         ----------
-        dsname: None or str
+        dsname : None or str
             If there is more than one datastream in the display object the
             name of the datastream needs to be specified. If set to None and
             there is only one datastream then ACT will use the sole datastream
             in the object.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index to the subplot to place the day and night background in.
 
         """
-
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream to derive the " +
                               "information needed for the day and night " +
@@ -116,9 +115,9 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        xrng: 2 number array
+        xrng : 2 number array
             The x limits of the plot.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         """
@@ -141,9 +140,9 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        yrng: 2 number array
+        yrng : 2 number array
             The y limits of the plot.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         """
@@ -172,39 +171,39 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        field: str
+        field : str
             The name of the field to plot
-        dsname: None or str
+        dsname : None or str
             If there is more than one datastream in the display object the
             name of the datastream needs to be specified. If set to None and
             there is only one datastream ACT will use the sole datastream
             in the object.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
-        cmap: matplotlib colormap
+        cmap : matplotlib colormap
             The colormap to use.
-        cbmin: float
+        cbmin : float
             The minimum for the colorbar. This is not used for 1D plots.
-        cbmax: float
+        cbmax : float
             The maximum for the colorbar. This is not used for 1D plots.
-        set_title: str
+        set_title : str
             The title for the plot.
-        add_nan: bool
+        add_nan : bool
             Set to True to fill in data gaps with NaNs.
-        day_night_background: bool
+        day_night_background : bool
             Set to True to fill in a color coded background
             according to the time of day.
-        abs_limits: tuple or list
+        abs_limits : tuple or list
             Sets the bounds on plot limits even if data values exceed
             those limits. Set to (ymin,ymax). Use None if only setting
-            minimum or maximum limit, i.e. (22., None)
-        kwargs: dict
+            minimum or maximum limit, i.e. (22., None).
+        **kwargs : keyword arguments
             The keyword arguments for :func:`plt.plot` (1D timeseries) or
             :func:`plt.pcolormesh` (2D timeseries).
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The matplotlib axis handle of the plot.
 
         """
@@ -350,26 +349,26 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        dir_field: str
+        dir_field : str
             The name of the field specifying the wind direction in degrees.
             0 degrees is defined to be north and increases clockwise like
             what is used in standard meteorological notation.
-        spd_field: str
+        spd_field : str
             The name of the field specifying the wind speed in m/s.
-        pres_field: str
+        pres_field : str
             The name of the field specifying pressure or height. If using
             height coordinates, then we recommend setting invert_y_axis
             to False.
-        dsname: str
+        dsname : str
             The name of the datastream to plot. Setting to None will make
             ACT attempt to autodetect this.
-        kwargs: dict
+        kwargs : dict
             Any additional keyword arguments will be passed into
             :func:`act.plotting.TimeSeriesDisplay.plot_barbs_from_u_and_v`.
 
         Returns
         -------
-        the_ax: matplotlib axis handle
+        the_ax : matplotlib axis handle
             The handle to the axis where the plot was made on.
 
         Examples
@@ -418,35 +417,35 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        u_field: str
+        u_field : str
             The name of the field containing the U component of the wind.
-        v_field: str
+        v_field : str
             The name of the field containing the V component of the wind.
-        pres_field: str or None
+        pres_field : str or None
             The name of the field containing the pressure or height. Set
             to None to not use this.
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot. Setting to None will make
             ACT automatically try to determine this.
-        subplot_index: 2-tuple
+        subplot_index : 2-tuple
             The index of the subplot to make the plot on.
-        set_title: str or None
+        set_title : str or None
             The title of the plot.
-        day_night_background: bool
+        day_night_background : bool
             Set to True to plot a day/night background.
-        invert_y_axis: bool
+        invert_y_axis : bool
             Set to True to invert the y axis (i.e. for plotting pressure as
             the height coordinate).
-        num_barbs_x: int
+        num_barbs_x : int
             The number of wind barbs to plot in the x axis.
-        num_barbs_y: int
+        num_barbs_y : int
             The number of wind barbs to plot in the y axis.
-        kwargs: dict
+        **kwargs : keyword arguments
             Additional keyword arguments will be passed into plt.barbs.
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
              The axis handle that contains the reference to the
              constructed plot.
 
@@ -584,37 +583,37 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        data_field: str
+        data_field : str
             The name of the field to plot.
-        pres_field: str
+        pres_field : str
             The name of the height or pressure field to plot.
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot
-        subplot_index: 2-tuple
+        subplot_index : 2-tuple
             The index of the subplot to create the plot on.
-        set_title: str or None
+        set_title : str or None
             The title of the plot.
-        day_night_background: bool
-            Set to true to plot the day/night background
-        num_time_periods: int
+        day_night_background : bool
+            Set to true to plot the day/night background.
+        num_time_periods : int
             Set to determine how many time periods. Setting to None
             will do one time period per day.
-        num_y_levels: int
-            The number of levels in the y axis to use
-        cbmin: float
+        num_y_levels : int
+            The number of levels in the y axis to use.
+        cbmin : float
             The minimum for the colorbar.
-        cbmax: float
+        cbmax : float
             The maximum for the colorbar.
-        invert_y_axis: bool
+        invert_y_axis : bool
              Set to true to invert the y-axis (recommended for
-             pressure coordinates)
-        kwargs: dict
+             pressure coordinates).
+        **kwargs : keyword arguments
              Additional keyword arguments will be passed
              into :func:`plt.pcolormesh`
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The matplotlib axis handle pointing to the plot.
 
         """
@@ -731,23 +730,23 @@ class TimeSeriesDisplay(Display):
 
         Parameters
         ----------
-        data_field: str
-            Name of data field in the object to plot on second y-axis
-        height_field: str
+        data_field : str
+            Name of data field in the object to plot on second y-axis.
+        height_field : str
             Name of height field in the object to plot on first y-axis.
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot.
-        cmap: str
+        cmap : str
             Colorbar corlor map to use.
-        alt_label: str
-            Altitued first y-axis label to use. If not set will try to use
+        alt_label : str
+            Altitude first y-axis label to use. If None, will try to use
             long_name and units.
-        alt_field: str
+        alt_field : str
             Label for field in the object to plot on first y-axis.
-        cb_label: str
+        cb_label : str
             Colorbar label to use. If not set will try to use
             long_name and units.
-        **kwargs: keyword arguments
+        **kwargs : keyword arguments
             Any other keyword arguments that will be passed
             into TimeSeriesDisplay.plot module when the figure
             is made.

--- a/act/plotting/TimeSeriesDisplay.py
+++ b/act/plotting/TimeSeriesDisplay.py
@@ -206,6 +206,7 @@ class TimeSeriesDisplay(Display):
         -------
         ax: matplotlib axis handle
             The matplotlib axis handle of the plot.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "
@@ -381,8 +382,8 @@ class TimeSeriesDisplay(Display):
                 {'sonde_darwin': sonde_ds}, figsize=(10,5))
             BarbDisplay.plot_barbs_from_spd_dir('deg', 'wspd', 'pres',
                                                 num_barbs_x=20)
-        """
 
+        """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "
                               "or more datasets in the TimeSeriesDisplay "
@@ -448,6 +449,7 @@ class TimeSeriesDisplay(Display):
         ax: matplotlib axis handle
              The axis handle that contains the reference to the
              constructed plot.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "
@@ -614,6 +616,7 @@ class TimeSeriesDisplay(Display):
         -------
         ax: matplotlib axis handle
             The matplotlib axis handle pointing to the plot.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2"
@@ -721,7 +724,7 @@ class TimeSeriesDisplay(Display):
             self, data_field=None, dsname=None, cmap='rainbow',
             alt_label=None, alt_field='alt', cb_label=None, **kwargs):
         """
-        Create a time series plot of altitued and data varible with
+        Create a time series plot of altitude and data variable with
         color also indicating value with a color bar. The Color bar is
         positioned to serve both as the indicator of the color intensity
         and the second y-axis.
@@ -733,7 +736,7 @@ class TimeSeriesDisplay(Display):
         height_field: str
             Name of height field in the object to plot on first y-axis.
         dsname: str or None
-            The name of the datastream to plot
+            The name of the datastream to plot.
         cmap: str
             Colorbar corlor map to use.
         alt_label: str
@@ -748,6 +751,7 @@ class TimeSeriesDisplay(Display):
             Any other keyword arguments that will be passed
             into TimeSeriesDisplay.plot module when the figure
             is made.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "

--- a/act/plotting/WindRoseDisplay.py
+++ b/act/plotting/WindRoseDisplay.py
@@ -20,7 +20,7 @@ class WindRoseDisplay(Display):
     This is inherited from the :func:`act.plotting.Display`
     class and has therefore has the same attributes as that class.
     See :func:`act.plotting.Display`
-    for more information.  There are no additional attributes or parameters
+    for more information. There are no additional attributes or parameters
     to this class.
 
     Examples

--- a/act/plotting/WindRoseDisplay.py
+++ b/act/plotting/WindRoseDisplay.py
@@ -25,7 +25,6 @@ class WindRoseDisplay(Display):
 
     Examples
     --------
-
     To create a WindRoseDisplay object, simply do:
 
     .. code-block :: python
@@ -44,10 +43,11 @@ class WindRoseDisplay(Display):
 
         Parameters
         ----------
-        trng: 2-tuple
+        trng : 2-tuple
             The range (in degrees).
-        subplot_index: 2-tuple
+        subplot_index : 2-tuple
             The index of the subplot to set the degree range of.
+
         """
         if self.axes is not None:
             self.axes[subplot_index].set_thetamin(np.deg2rad(trng[0]))
@@ -63,10 +63,11 @@ class WindRoseDisplay(Display):
 
         Parameters
         ----------
-        rrng: 2-tuple
+        rrng : 2-tuple
             The range for the plot radius (in %).
-        subplot_index: 2-tuple
+        subplot_index : 2-tuple
             The index of the subplot to set the radius range of.
+
         """
         if self.axes is not None:
             self.axes[subplot_index].set_thetamin(rrng[0])
@@ -84,32 +85,33 @@ class WindRoseDisplay(Display):
 
         Parameters
         ----------
-        dir_field: str
+        dir_field : str
             The name of the field representing the wind direction (in degrees).
-        spd_field: str
+        spd_field : str
             The name of the field representing the wind speed.
-        dsname: str
+        dsname : str
             The name of the datastream to plot from. Set to None to
             let ACT automatically try to determine this.
-        subplot_index: 2-tuple
-            The index of the subplot to place the plot on
-        cmap: str or matplotlib colormap
+        subplot_index : 2-tuple
+            The index of the subplot to place the plot on.
+        cmap : str or matplotlib colormap
             The name of the matplotlib colormap to use.
-        set_title: str
+        set_title : str
             The title of the plot.
-        num_dirs: int
+        num_dirs : int
             The number of directions to split the wind rose into.
-        spd_bins: 1D array-like
+        spd_bins : 1D array-like
             The bin boundaries to sort the wind speeds into.
-        tick_interval:
+        tick_interval : int
             The interval (in %) for the ticks on the radial axis.
-        kwargs:
+        **kwargs : keyword arguments
             Additional keyword arguments will be passed into :func:plt.bar
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The matplotlib axis handle corresponding to the plot.
+
         """
         if dsname is None and len(self._arm.keys()) > 1:
             raise ValueError(("You must choose a datastream when there are 2 "

--- a/act/plotting/XSectionDisplay.py
+++ b/act/plotting/XSectionDisplay.py
@@ -31,7 +31,7 @@ class XSectionDisplay(Display):
     This is inherited from the :func:`act.plotting.Display`
     class and has therefore has the same attributes as that class.
     See :func:`act.plotting.Display`
-    for more information.  There are no additional attributes or parameters
+    for more information. There are no additional attributes or parameters
     to this class.
 
     In order to create geographic plots, ACT needs the Cartopy package to be
@@ -176,7 +176,7 @@ class XSectionDisplay(Display):
             :func:`xarray.DataArray.plot`
 
         Returns
-        =======
+        -------
         ax: matplotlib axis handle
             The matplotlib axis handle corresponding to the plot.
 
@@ -250,10 +250,10 @@ class XSectionDisplay(Display):
                           subplot_index=(0, ), coastlines=True,
                           background=False, **kwargs):
         """
-        Plots a cross section of 2D data on a geographical map
+        Plots a cross section of 2D data on a geographical map.
 
         Parameters
-        ==========
+        ----------
         dsname: str or None
             The name of the datastream to plot from. Set to None
             to have ACT attempt to automatically detect this.
@@ -270,11 +270,11 @@ class XSectionDisplay(Display):
             :func:`act.plotting.XSectionDisplay.plot_xsection`
 
         Returns
-        =======
+        -------
         ax: matplotlib axis handle
             The matplotlib axis handle corresponding to the plot.
-        """
 
+        """
         if not CARTOPY_AVAILABLE:
             raise ImportError("Cartopy needs to be installed in order to plot " +
                               "cross sections on maps!")

--- a/act/plotting/XSectionDisplay.py
+++ b/act/plotting/XSectionDisplay.py
@@ -40,7 +40,6 @@ class XSectionDisplay(Display):
 
     Examples
     --------
-
     For example, if you only want to do a cross section through the first
     time period of a 3D dataset called :code:`ir_temperature`, you would
     do the following in xarray:
@@ -64,6 +63,7 @@ class XSectionDisplay(Display):
     Here, the array is sliced by the first time period as specified in :code:`isel_kwargs`.
     The other keyword arguments are standard keyword arguments taken by
     :func:`matplotlib.pyplot.pcolormesh`.
+
     """
     def __init__(self, obj, subplot_shape=(1,),
                  ds_name=None, **kwargs):
@@ -92,9 +92,9 @@ class XSectionDisplay(Display):
 
         Parameters
         ----------
-        xrng: 2 number array
+        xrng : 2 number array
             The x limits of the plot.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         """
@@ -117,9 +117,9 @@ class XSectionDisplay(Display):
 
         Parameters
         ----------
-        yrng: 2 number array
+        yrng : 2 number array
             The y limits of the plot.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         """
@@ -144,40 +144,38 @@ class XSectionDisplay(Display):
                       sel_kwargs=None, isel_kwargs=None,
                       **kwargs):
         """
-        This function plots a cross section whose x and y
-        coordinates are specified by the variable
-        names either provided by the user or automatically
-        detected by xarray.
+        This function plots a cross section whose x and y coordinates are
+        specified by the variable names either provided by the user or
+        automatically detected by xarray.
 
         Parameters
         ----------
-        dsname: str or None
-            The name of the datastream to plot from. Set to
-            None to have ACT attempt to automatically
-            detect this.
-        varname: str
-            The name of the variable to plot
-        x: str or None
-            The name of the x coordinate variable
-        y: str or None
-            The name of the y coordinate variable
-        subplot_index: tuple
-            The index of the subplot to create the plot in
-        sel_kwargs: dict
+        dsname : str or None
+            The name of the datastream to plot from. Set to None to have
+            ACT attempt to automatically detect this.
+        varname : str
+            The name of the variable to plot.
+        x : str or None
+            The name of the x coordinate variable.
+        y : str or None
+            The name of the y coordinate variable.
+        subplot_index : tuple
+            The index of the subplot to create the plot in.
+        sel_kwargs : dict
             The keyword arguments to pass into :py:func:`xarray.DataArray.sel`
             This is useful when your data is in 3 or more dimensions and you
             want to only view a cross section on a specific x-y plane. For more
             information on how to use xarray's .sel and .isel functionality
             to slice datasets, see the documentation on :func:`xarray.DataArray.sel`.
-        isel_kwargs:
+        isel_kwargs : dict
             The keyword arguments to pass into :py:func:`xarray.DataArray.sel`
-        kwargs:
+        **kwargs : keyword arguments
             Additional keyword arguments will be passed into
-            :func:`xarray.DataArray.plot`
+            :func:`xarray.DataArray.plot`.
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The matplotlib axis handle corresponding to the plot.
 
         """
@@ -254,18 +252,18 @@ class XSectionDisplay(Display):
 
         Parameters
         ----------
-        dsname: str or None
+        dsname : str or None
             The name of the datastream to plot from. Set to None
             to have ACT attempt to automatically detect this.
-        varname: str
+        varname : str
             The name of the variable to plot.
-        subplot_index: tuple
+        subplot_index : tuple
             The index of the subplot to plot inside.
-        coastlines: bool
+        coastlines : bool
             Set to True to plot the coastlines.
-        background: bool
-            Set to True to plot a stock image background
-        kwargs:
+        background : bool
+            Set to True to plot a stock image background.
+        **kwargs : keyword arguments
             Additional keyword arguments will be passed into
             :func:`act.plotting.XSectionDisplay.plot_xsection`
 

--- a/act/plotting/common.py
+++ b/act/plotting/common.py
@@ -1,6 +1,10 @@
-###########################
-# Common Plotting Methods #
-###########################
+"""
+act.plotting.common
+-------------------
+
+Functions common between plotting modules.
+
+"""
 
 import matplotlib.pyplot as plt
 from matplotlib.dates import (DateFormatter, HourLocator, DayLocator)
@@ -12,12 +16,12 @@ def parse_ax(ax):
 
     Parameters
     ----------
-    ax: matplotlib axis
+    ax : matplotlib axis
         The matplotlib axis to be parsed. Set to none to get the current axis.
 
     Returns
     -------
-    ax: matplotlib axis
+    ax : matplotlib axis
         The target matplotlib axis.
 
     """
@@ -32,18 +36,18 @@ def parse_ax_fig(ax, fig):
 
     Parameters
     ----------
-    ax: matplotlib axis
+    ax : matplotlib axis
         The matplotlib axis to be parsed. Set to None to get the current axis.
-    fig: matplotlib fig
+    fig : matplotlib fig
         The matplotlib figure to be parsed.
         Set to None to get the current figure.
 
     Returns
     -------
-    ax: matplotlib axis
+    ax : matplotlib axis
         The target matplotlib axis.
-    fig: matplotlib figure
-        The targer matplotlib figure.
+    fig : matplotlib figure
+        The target matplotlib figure.
 
     """
     if ax is None:
@@ -59,15 +63,15 @@ def get_date_format(days, day_to_hour_threshold=3):
 
     Parameters
     ----------
-    days: float
+    days : float
         The number of days we are plotting.
-    day_to_hour_threshold: float
+    day_to_hour_threshold : float
         If the dataset is under this threshold long, format the x axis ticks
         by hour instead of date.
 
     Returns
     -------
-    myFmt: matplotlib DateFormatter
+    myFmt : matplotlib DateFormatter
         The DateFormatter object to use for the plot.
 
     """

--- a/act/plotting/common.py
+++ b/act/plotting/common.py
@@ -19,8 +19,8 @@ def parse_ax(ax):
     -------
     ax: matplotlib axis
         The target matplotlib axis.
-    """
 
+    """
     if ax is None:
         ax = plt.gca()
     return ax
@@ -44,6 +44,7 @@ def parse_ax_fig(ax, fig):
         The target matplotlib axis.
     fig: matplotlib figure
         The targer matplotlib figure.
+
     """
     if ax is None:
         ax = plt.gca()
@@ -68,6 +69,7 @@ def get_date_format(days, day_to_hour_threshold=3):
     -------
     myFmt: matplotlib DateFormatter
         The DateFormatter object to use for the plot.
+
     """
     # Set format for time axis if needed
     if days > day_to_hour_threshold:

--- a/act/plotting/plot.py
+++ b/act/plotting/plot.py
@@ -133,8 +133,8 @@ class Display(object):
             into :func:`matplotlib.pyplot.subplots`. See the matplotlib
             documentation for further details on what keyword
             arguments are available.
-        """
 
+        """
         if self.fig is not None:
             plt.close(self.fig)
             del self.fig
@@ -177,8 +177,8 @@ class Display(object):
         -------
         ax: matplotlib axis handle
             The axis handle to the display object being added.
-        """
 
+        """
         if len(display.axes) > 1:
             raise RuntimeError("Only single plots can be made as subplots " +
                                "of another Display object!")
@@ -212,9 +212,9 @@ class Display(object):
         Parameters
         ----------
         fig: matplotlib figure handle
-            The figure to place the time series display in
+            The figure to place the time series display in.
         ax: axis handle
-            The axis handle to place the plot in
+            The axis handle to place the plot in.
 
         """
         if self.fig is not None:
@@ -227,7 +227,7 @@ class Display(object):
 
     def add_colorbar(self, mappable, title=None, subplot_index=(0, )):
         """
-        Adds a colorbar to the plot
+        Adds a colorbar to the plot.
 
         Parameters
         ----------
@@ -242,6 +242,7 @@ class Display(object):
         -------
         cbar: matplotlib colorbar handle
             The handle to the matplotlib colorbar.
+
         """
         if self.axes is None:
             raise RuntimeError("add_colorbar requires the plot "

--- a/act/plotting/plot.py
+++ b/act/plotting/plot.py
@@ -1,6 +1,6 @@
 """
-act.plotting
-============
+act.plotting.plot
+=================
 
 Class for creating timeseries plots from ACT datasets.
 
@@ -29,44 +29,44 @@ class Display(object):
 
     Attributes
     ----------
-    fields: dict
+    fields : dict
         The dictionary containing the fields inside the ARM dataset. Each field
         has a key that links to an xarray DataArray object.
-    ds: str
+    ds : str
         The name of the datastream.
-    file_dates: list
+    file_dates : list
         The dates of each file being displayed.
-    fig: matplotlib figure handle
+    fig : matplotlib figure handle
         The matplotlib figure handle to display the plots on. Initializing the
         class with this set to None will create a new figure handle. See the
         matplotlib documentation on what keyword arguments are
         available.
-    axes: list
+    axes : list
         The list of axes handles to each subplot.
-    plot_vars: list
+    plot_vars : list
         The list of variables being plotted.
-    cbs: list
+    cbs : list
         The list of colorbar handles.
 
     Parameters
     ----------
-    obj: ACT Dataset, dict, or tuple
+    obj : ACT Dataset, dict, or tuple
         The ACT Dataset to display in the object. If more than one dataset
         is to be specified, then a tuple can be used if all of the datasets
         conform to ARM standards. Otherwise, a dict with a key corresponding
         to the name of each datastream will need to be supplied in order
         to create the ability to plot multiple datasets.
-    subplot_shape: 1 or 2D tuple
+    subplot_shape : 1 or 2D tuple
         A tuple representing the number of (rows, columns) for the subplots
         in the display. If this is None, the figure and axes will not
         be initialized.
-    ds_name: str or None
+    ds_name : str or None
         The name of the datastream to plot. This is only used if a non-ARM
         compliant dataset is being loaded and if only one such dataset is
         loaded.
-    subplot_kw: dict, optional
+    subplot_kw : dict, optional
         The kwargs to pass into :func:`fig.subplots`
-    **kwargs:
+    **kwargs : keywords arguments
         Keyword arguments passed to :func:`plt.figure`.
 
     """
@@ -124,11 +124,11 @@ class Display(object):
 
         Parameters
         ----------
-        subplot_shape: 1 or 2D tuple, list, or array
+        subplot_shape : 1 or 2D tuple, list, or array
             The structure of the subplots in (rows, cols).
-        subplot_kw: dict, optional
+        subplot_kw : dict, optional
             The kwargs to pass into fig.subplots.
-        **kwargs: keyword arguments
+        **kwargs : keyword arguments
             Any other keyword arguments that will be passed
             into :func:`matplotlib.pyplot.subplots`. See the matplotlib
             documentation for further details on what keyword
@@ -168,14 +168,14 @@ class Display(object):
 
         Parameters
         ----------
-        Display: Display object or subclass
+        Display : Display object or subclass
             The Display object to add as a subplot
-        subplot_index: tuple
+        subplot_index : tuple
             Which subplot to add the Display to.
 
         Returns
         -------
-        ax: matplotlib axis handle
+        ax : matplotlib axis handle
             The axis handle to the display object being added.
 
         """
@@ -211,9 +211,9 @@ class Display(object):
 
         Parameters
         ----------
-        fig: matplotlib figure handle
+        fig : matplotlib figure handle
             The figure to place the time series display in.
-        ax: axis handle
+        ax : axis handle
             The axis handle to place the plot in.
 
         """
@@ -231,16 +231,16 @@ class Display(object):
 
         Parameters
         ----------
-        mappable: matplotlib mappable
+        mappable : matplotlib mappable
             The mappable to base the colorbar on.
-        title: str
+        title : str
             The title of the colorbar. Set to None to have no title.
-        subplot_index: 1 or 2D tuple, list, or array
+        subplot_index : 1 or 2D tuple, list, or array
             The index of the subplot to set the x range of.
 
         Returns
         -------
-        cbar: matplotlib colorbar handle
+        cbar : matplotlib colorbar handle
             The handle to the matplotlib colorbar.
 
         """

--- a/act/retrievals/stability_indices.py
+++ b/act/retrievals/stability_indices.py
@@ -37,8 +37,8 @@ def calculate_stability_indicies(ds, temp_name="temperature",
     -------
     ds: ACT dataset
         An ACT dataset with additional stability indicies added.
-    """
 
+    """
     t = ds[temp_name]
     td = ds[td_name]
     p = ds[p_name]

--- a/act/retrievals/stability_indices.py
+++ b/act/retrievals/stability_indices.py
@@ -1,3 +1,10 @@
+"""
+act.retrievals.stability_indices
+--------------------------------
+
+Module that adds stability indicies to a dataset.
+
+"""
 import xarray as xr
 import numpy as np
 
@@ -16,26 +23,25 @@ def calculate_stability_indicies(ds, temp_name="temperature",
                                  p_name="pressure",
                                  moving_ave_window=0):
     """
-
     Parameters
     ----------
-    ds: ACT dataset
+    ds : ACT dataset
         The dataset to compute the stability indicies of. Must have
         temperature, dewpoint, and pressure in vertical coordinates.
-    temp_name: str
+    temp_name : str
         The name of the temperature field.
-    td_name: str
+    td_name : str
         The name of the dewpoint field.
-    p_name: str
+    p_name : str
         The name of the pressure field.
-    moving_ave_window: int
+    moving_ave_window : int
         Number of points to do a moving average on sounding
         data to reduce noise. This is useful if noise in the
         sounding is preventing parcel ascent.
 
     Returns
     -------
-    ds: ACT dataset
+    ds : ACT dataset
         An ACT dataset with additional stability indicies added.
 
     """

--- a/act/tests/test_utils.py
+++ b/act/tests/test_utils.py
@@ -8,7 +8,7 @@ def test_dates_between():
     start_date = '20190101'
     end_date = '20190110'
 
-    date_list = act.utils.datetime_utils.dates_between(start_date, end_date)
+    date_list = act.utils.dates_between(start_date, end_date)
     answer = [datetime(2019, 1, 1),
               datetime(2019, 1, 2),
               datetime(2019, 1, 3),
@@ -33,7 +33,7 @@ def add_in_nan():
 
     time_list = xr.DataArray(time_list)
     data = xr.DataArray(data)
-    data_filled, time_filled = act.utils.data_utils.add_in_nan(
+    data_filled, time_filled = act.utils.add_in_nan(
         time_list, data)
     assert(data_filled.data == np.array([0, 2, 4, 6,
                                          np.nan, np.nan, np.nan, np.nan,

--- a/act/utils/__init__.py
+++ b/act/utils/__init__.py
@@ -5,17 +5,18 @@ act.utils (act.utils)
 
 .. currentmodule:: act.utils
 
-This module contains the common procedues used by all modules of the ARM
+This module contains the common procedures used by all modules of the ARM
 Community Toolkit.
 
 .. autosummary::
     :toctree: generated/
 
-    datetime_utils.dates_between
-    data_utils.add_in_nan
-    data_utils.get_missing_value
-    data_utils.assign_coordinates
+    dates_between
+    add_in_nan
+    get_missing_value
+    assign_coordinates
 """
 
-from . import datetime_utils
-from . import data_utils
+from .data_utils import add_in_nan, get_missing_value
+from .data_utils import assign_coordinates
+from .datetime_utils import dates_between

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -1,3 +1,10 @@
+"""
+act.utils.data_utils
+--------------------
+
+Module containing utilities for the data.
+
+"""
 import numpy as np
 import scipy.stats as stats
 import xarray as xr
@@ -11,15 +18,15 @@ def assign_coordinates(ds, coord_list):
 
     Parameters
     ----------
-    ds: ACT Dataset
+    ds : ACT Dataset
         The ACT Dataset to modify the coordinates of.
-    coord_list: dict
+    coord_list : dict
         The list of variables to assign as coordinates, given as a dictionary
         whose keys are the variable name and values are the dimension name.
 
     Returns
     -------
-    new_ds: ACT Dataset
+    new_ds : ACT Dataset
         The new ACT Dataset with the coordinates assigned to be the given
         variables.
 
@@ -61,17 +68,17 @@ def add_in_nan(time, data):
 
     Parameters
     ----------
-    time: 1D array of np.datetime64
+    time : 1D array of np.datetime64
         List of times in the timeseries.
-    data: 1 or 2D array
+    data : 1 or 2D array
         Array containing the data. The 0 axis corresponds to time.
 
     Returns
     -------
-    d_time: xarray DataArray
+    d_time : xarray DataArray
         The xarray DataArray containing the new times at regular intervals.
         The intervals are determined by the mode of the timestep in *time*.
-    d_data: xarray DataArray
+    d_data : xarray DataArray
         The xarray DataArray containing the NaN-filled data.
 
     """
@@ -107,30 +114,31 @@ def add_in_nan(time, data):
 
 def get_missing_value(self, variable, default=-9999, add_if_missing_in_obj=False,
                       use_FillValue=False, nodefault=False):
-    """ Method to get missing value from missing_value or _FillValue attribute.
+    """
+    Method to get missing value from missing_value or _FillValue attribute.
     Works well with catching errors and allows for a default value when a
     missing value is not listed in the object.
 
     Parameters
     ----------
-    variable: str
+    variable : str
         Variable name to use for getting missing value.
-    default: int or float
+    default : int or float
         Default value to use if missing value attribute is not in data object.
     add_if_missing_in_obj : bool
         Boolean to add to object if does not exist. Default is False.
-    use_FillValue: bool
+    use_FillValue : bool
         Boolean to use _FillValue instead of missing_value. If missing_value
         does exist and _FillValue does not with add_if_missing_in_obj set to
         True, will add _FillValue set to missing_value value. Default is False.
-    nodefault: bool
+    nodefault : bool
         Option to use this to check if the varible has a missing value set and
-        do not want to get default as retun. If the missing value is found
+        do not want to get default as return. If the missing value is found
         will return, else will return None.
 
     Returns
     -------
-    missing: scalar int or float (or None)
+    missing : scalar int or float (or None)
         Value used to indicate missing value matching type of data or None if
         nodefault keyword set to True.
 

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -5,9 +5,9 @@ import xarray as xr
 
 def assign_coordinates(ds, coord_list):
     """
-    This procedure will create a new ACT dataset whose coordinates are designated
-    to be the variables in a given list. This helps make data slicing via xarray
-    and visualization easier.
+    This procedure will create a new ACT dataset whose coordinates are
+    designated to be the variables in a given list. This helps make data
+    slicing via xarray and visualization easier.
 
     Parameters
     ----------
@@ -20,9 +20,10 @@ def assign_coordinates(ds, coord_list):
     Returns
     -------
     new_ds: ACT Dataset
-        The new ACT Dataset with the coordinates assigned to be the given variables.
-    """
+        The new ACT Dataset with the coordinates assigned to be the given
+        variables.
 
+    """
     # Check to make sure that user assigned valid entries for coordinates
 
     for coord in coord_list.keys():
@@ -58,22 +59,22 @@ def add_in_nan(time, data):
     corresponding data available. This is useful for timeseries that have
     irregular gaps in data.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     time: 1D array of np.datetime64
-        List of times in the timeseries
+        List of times in the timeseries.
     data: 1 or 2D array
         Array containing the data. The 0 axis corresponds to time.
 
-    Returns:
-    --------
+    Returns
+    -------
     d_time: xarray DataArray
         The xarray DataArray containing the new times at regular intervals.
         The intervals are determined by the mode of the timestep in *time*.
     d_data: xarray DataArray
         The xarray DataArray containing the NaN-filled data.
-    """
 
+    """
     diff = time.diff(dim='time', n=1) / np.timedelta64(1, 's')
     mode = stats.mode(diff).mode[0]
     index = np.where(diff.values > 2. * mode)
@@ -106,30 +107,30 @@ def add_in_nan(time, data):
 
 def get_missing_value(self, variable, default=-9999, add_if_missing_in_obj=False,
                       use_FillValue=False, nodefault=False):
-    '''Method to get missing value from missing_value or _FillValue attribute.
-    Works well with catching errors and allows for a default value when a missing
-    value is not listed in the object.
+    """ Method to get missing value from missing_value or _FillValue attribute.
+    Works well with catching errors and allows for a default value when a
+    missing value is not listed in the object.
 
     Parameters
     ----------
-    variable : str
+    variable: str
         Variable name to use for getting missing value.
-    default : int or float
-        Default value to use if missing value attribute is not in data object
+    default: int or float
+        Default value to use if missing value attribute is not in data object.
     add_if_missing_in_obj : bool
         Boolean to add to object if does not exist. Default is False.
-    use_FillValue : bool
+    use_FillValue: bool
         Boolean to use _FillValue instead of missing_value. If missing_value
         does exist and _FillValue does not with add_if_missing_in_obj set to
         True, will add _FillValue set to missing_value value. Default is False.
-    nodefault : bool
-        Option to use this to check if the varible has a missing value set and do not
-        want to get default as retun. If the missing value is found will return,
-        else will return None.
+    nodefault: bool
+        Option to use this to check if the varible has a missing value set and
+        do not want to get default as retun. If the missing value is found
+        will return, else will return None.
 
     Returns
     -------
-    missing : scalar int or float (or None)
+    missing: scalar int or float (or None)
         Value used to indicate missing value matching type of data or None if
         nodefault keyword set to True.
 
@@ -139,8 +140,7 @@ def get_missing_value(self, variable, default=-9999, add_if_missing_in_obj=False
     >>> missing
     -9999.0
 
-    '''
-
+    """
     in_object = False
     if use_FillValue:
         missing_atts = ['_FillValue', 'missing_value']

--- a/act/utils/datetime_utils.py
+++ b/act/utils/datetime_utils.py
@@ -1,3 +1,10 @@
+"""
+act.utils.datetime_utils
+------------------------
+
+Module that containing utilities involving datetimes.
+
+"""
 import datetime as dt
 import pandas as pd
 
@@ -8,16 +15,16 @@ def dates_between(sdate, edate):
 
     Parameters
     ----------
-    sdate: str
+    sdate : str
         The string containing the start date. The string is formatted
         YYYYMMDD.
-    edate: str
+    edate : str
         The string containing the end date. The string is formatted
         YYYYMMDD.
 
     Returns
     -------
-    all_dates: array of datetimes
+    all_dates : array of datetimes
         The array containing the dates between *sdate* and *edate*.
 
     """
@@ -35,12 +42,12 @@ def numpy_to_arm_date(_date):
 
     Parameters
     ----------
-    date: numpy.datetime64
+    date : numpy.datetime64
         Numpy datetime64 date.
 
     Returns
     -------
-    arm_date: string
+    arm_date : string
         Returns an arm date.
 
     """

--- a/act/utils/datetime_utils.py
+++ b/act/utils/datetime_utils.py
@@ -18,7 +18,8 @@ def dates_between(sdate, edate):
     Returns
     -------
     all_dates: array of datetimes
-        The array containing the dates between *sdate* and *edate*
+        The array containing the dates between *sdate* and *edate*.
+
     """
     days = dt.datetime.strptime(edate, '%Y%m%d') - \
         dt.datetime.strptime(sdate, '%Y%m%d')
@@ -30,17 +31,18 @@ def dates_between(sdate, edate):
 
 def numpy_to_arm_date(_date):
     """
-    Given a numpy datetime64, return an ARM standard date (yyyymmdd)
+    Given a numpy datetime64, return an ARM standard date (yyyymmdd).
 
     Parameters
     ----------
     date: numpy.datetime64
-        Numpy datetime64 date
+        Numpy datetime64 date.
 
     Returns
     -------
     arm_date: string
-        Returns an arm date
+        Returns an arm date.
+
     """
     date = pd.to_datetime(str(_date))
     date = date.strftime('%Y%m%d')

--- a/docs/source/API/generated/act.corrections.ceil.correct_ceil.rst
+++ b/docs/source/API/generated/act.corrections.ceil.correct_ceil.rst
@@ -1,6 +1,0 @@
-act.corrections.ceil.correct\_ceil
-==================================
-
-.. currentmodule:: act.corrections.ceil
-
-.. autofunction:: correct_ceil

--- a/docs/source/API/generated/act.plotting.common.get_date_format.rst
+++ b/docs/source/API/generated/act.plotting.common.get_date_format.rst
@@ -1,6 +1,0 @@
-act.plotting.common.get\_date\_format
-=====================================
-
-.. currentmodule:: act.plotting.common
-
-.. autofunction:: get_date_format

--- a/docs/source/API/generated/act.plotting.common.parse_ax.rst
+++ b/docs/source/API/generated/act.plotting.common.parse_ax.rst
@@ -1,6 +1,0 @@
-act.plotting.common.parse\_ax
-=============================
-
-.. currentmodule:: act.plotting.common
-
-.. autofunction:: parse_ax

--- a/docs/source/API/generated/act.plotting.common.parse_ax_fig.rst
+++ b/docs/source/API/generated/act.plotting.common.parse_ax_fig.rst
@@ -1,6 +1,0 @@
-act.plotting.common.parse\_ax\_fig
-==================================
-
-.. currentmodule:: act.plotting.common
-
-.. autofunction:: parse_ax_fig

--- a/docs/source/API/generated/act.utils.data_utils.add_in_nan.rst
+++ b/docs/source/API/generated/act.utils.data_utils.add_in_nan.rst
@@ -1,6 +1,0 @@
-act.utils.data\_utils.add\_in\_nan
-==================================
-
-.. currentmodule:: act.utils.data_utils
-
-.. autofunction:: add_in_nan

--- a/docs/source/API/generated/act.utils.datetime_utils.dates_between.rst
+++ b/docs/source/API/generated/act.utils.datetime_utils.dates_between.rst
@@ -1,6 +1,0 @@
-act.utils.datetime\_utils.dates\_between
-========================================
-
-.. currentmodule:: act.utils.datetime_utils
-
-.. autofunction:: dates_between


### PR DESCRIPTION
To be more consistent between submodules and code, added colon between parameter definitions in docs. Fixed a few spelling errors and added space at the end of doc strings to be more in line with nump standards. I also changed the import of the utils to remove the need for a longer extension. IO import are the same to keep different datatype modules separate. 