### PR TITLE
qcfilter update

### DIFF
--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -210,15 +210,15 @@ class CleanDataset(object):
         try:
             if variable:
                 attr_description_pattern = (r"(^" + string +
-                                            r")_([0-9])_(description$)")
+                                            r")_([0-9]+)_(description$)")
                 attr_assessment_pattern = (r"(^" + string +
-                                           r")_([0-9])_(assessment$)")
+                                           r")_([0-9]+)_(assessment$)")
                 attributes = self._obj[variable].attrs
             else:
                 attr_description_pattern = (r"(^qc_" + string +
-                                            r")_([0-9])_(description$)")
+                                            r")_([0-9]+)_(description$)")
                 attr_assessment_pattern = (r"(^qc_" + string +
-                                           r")_([0-9])_(assessment$)")
+                                           r")_([0-9]+)_(assessment$)")
                 attributes = self._obj.attrs
         except KeyError:
             return None

--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -62,7 +62,8 @@ class QCFilter(object):
         """ initialize """
         self._obj = xarray_obj
 
-    def check_for_ancillary_qc(self, var_name, add_if_missing=True):
+    def check_for_ancillary_qc(self, var_name, add_if_missing=True,
+                               cleanup=True):
         '''
         Method to check for corresponding quality control variable in
         the dataset. If it does not exist will create and correctly
@@ -75,6 +76,10 @@ class QCFilter(object):
             data variable name
         add_if_missing : boolean
             Add quality control variable if missing from object
+        cleanup : boolean
+            Option to run io.clean.cleanup() method on the object
+            to ensure the object was updated from ARM QC to the
+            correct standardized QC.
 
         Returns
         -------
@@ -113,6 +118,12 @@ class QCFilter(object):
         # data variable to QC variable.
         if add_if_missing:
             self._obj.qcfilter.update_ancillary_variable(var_name, qc_var_name)
+
+        # Clean up quality control variables to the requried standard in the
+        # xarray object. If the quality control variables are already cleaned
+        # the extra work is small since it's just checking.
+        if cleanup:
+            self._obj.clean.cleanup(handle_missing_value=True, link_qc_variables=False)
 
         return qc_var_name
 


### PR DESCRIPTION
Adam pointed out that if the user reads in regular ARM data with embedded QC fields and does not run clean.cleanup() method on the object, the qcfilter methods will not work correctly. I've added a check into any of the qcfilter methods to run clean.cleanup() to ensure things work smoothly. I also updated clean.cleanup() to fix an issue with not translating bits higher than 9 and adding bit_#_comment attributes.