### PR TITLE
High lat background for plots

### DIFF
--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -455,9 +455,12 @@ class CleanDataset(object):
             except AttributeError:
                 continue
             # Skip data quality fields.
-            if not ('Quality check results on field:' in
-                    self._obj[var].attrs['long_name']):
-                continue
+            try:
+                if not ('Quality check results on field:' in
+                        self._obj[var].attrs['long_name']):
+                    continue
+            except KeyError:
+                pass
 
             # Get existing data variable ancillary_variables attribute
             try:


### PR DESCRIPTION
The exception to catch errors when plotting at high latitude and no sunset is not working correctly. I've updated the exception to use plot range instead of trying to get time range from object. Also, updated the exception to be more specific.

Added exception to catch errors when location variables are not in the object. It will do a smart search for known variable names first, then look for standard_name then return gracefully.

Also, minor issue with cleanup and checking long_name.