### PR TITLE
Fixing issue I introduced with recent update detecting QC variables.

### DIFF
--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -29,7 +29,7 @@ class CleanDataset(object):
                     "each bit represents a QC test on the data. Non-zero "
                     "bits indicate the QC condition given in the "
                     "description for those bits; a value of 0 "
-                    "(no bits set) indicates "
+                    "\(no bits set\) indicates "
                     "the data has not failed any QC tests."
                     ]
                    }


### PR DESCRIPTION
Fixing issue with "(" and ")"  in re after switching to new method for detecting QC variables.

I ran the pytest -v locally and there is a failure in something I didn't touch. Not sure if this will have a failure or not.