### PR TITLE
Return qc

### DIFF
--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -30,7 +30,9 @@ class CleanDataset(object):
                     "bits indicate the QC condition given in the "
                     "description for those bits; a value of 0 "
                     "\(no bits set\) indicates "
-                    "the data has not failed any QC tests."
+                    "the data has not failed any QC tests.",
+                    "This field contains bit packed values which should be "
+                    "interpreted as listed..+"
                     ]
                    }
 

--- a/act/plotting/TimeSeriesDisplay.py
+++ b/act/plotting/TimeSeriesDisplay.py
@@ -200,7 +200,7 @@ class TimeSeriesDisplay(Display):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", ".*Attempting to set identical "
-                                    "left == right .* automatically expanding.")
+                                    "left.*==.*right .*automatically expanding..*")
             self.axes[subplot_index].set_xlim(xrng)
             self.xrng[subplot_index, :] = np.array(xrng, dtype='datetime64[D]')
 

--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -601,7 +601,7 @@ class QCFilter(qctests.QCTests, object):
 
     def get_masked_data(self, var_name, rm_assessments=None,
                         rm_tests=None, return_nan_array=False,
-                        ma_fill_value=None):
+                        ma_fill_value=None, return_inverse=False):
 
         """
         Returns a numpy masked array containing data and mask or
@@ -624,6 +624,9 @@ class QCFilter(qctests.QCTests, object):
             The numpy masked array fill_value used in creation of the the
             masked array. If the datatype needs to be upconverted to allow
             the fill value to be used, data will be upconverted.
+        return_inverse : boolean
+            Invert the masked array mask or return data array where set to False
+            set to NaN. Useful for overplotting where failing.
 
         Returns : numpy masked array or numpy float array
         --------
@@ -711,6 +714,14 @@ class QCFilter(qctests.QCTests, object):
             variable = np.ma.array(variable, mask=mask,
                                    fill_value=ma_fill_value,
                                    dtype=np.array(ma_fill_value).dtype)
+
+        # If requested switch array from where data is not failing tests
+        # to where data is failing tests. This can be used when over plotting
+        # where the data if failing the tests.
+        if return_inverse:
+            mask = variable.mask
+            mask = np.invert(mask)
+            variable.mask = mask
 
         # If asked to return numpy array with values set to NaN
         if return_nan_array:


### PR DESCRIPTION
Adding option to return inverted masked array for indicating where test is not set. This will be used to overplot where failing. Also fixed an issue with additional description values for determining QC variables.