### PR TITLE
adding precipitable water calculation for sonde data

### DIFF
--- a/act/retrievals/__init__.py
+++ b/act/retrievals/__init__.py
@@ -12,7 +12,9 @@ This module contains various retrievals for ARM datsets.
 
     calculate_stability_indicies
     generic_sobel_cbh
+    calculate_precipitable_water
 """
 
 from .stability_indices import calculate_stability_indicies
 from .cbh import generic_sobel_cbh
+from .pwv_calc import calculate_precipitable_water

--- a/act/retrievals/pwv_calc.py
+++ b/act/retrievals/pwv_calc.py
@@ -37,17 +37,17 @@ def calculate_precipitable_water(ds, temp_name='tdry', rh_name='rh',
     for t in temperature:
         # Over liquid water, above freezing
         if t >= 0:
-            sat_vap_pres.append(0.61121 * np.exp((18.678-(t/234.5)) *
-                                (t/(257.14 + t))))
+            sat_vap_pres.append(0.61121 * np.exp((18.678 - (t / 234.5)) *
+                                (t / (257.14 + t))))
         # Over ice, below freezing
         else:
-            sat_vap_pres.append(0.61115 * np.exp((23.036 - (t/333.7)) *
-                                (t/(279.82 + t))))
+            sat_vap_pres.append(0.61115 * np.exp((23.036 - (t / 333.7)) *
+                                (t / (279.82 + t))))
 
     # convert rh from % to decimal
     rel_hum = []
     for r in np.nditer(rh):
-        rel_hum.append(r/100.)
+        rel_hum.append(r / 100.)
 
     # get vapor pressure from rh and saturation vapor pressure
     vap_pres = []
@@ -70,13 +70,14 @@ def calculate_precipitable_water(ds, temp_name='tdry', rh_name='rh',
 
     spec_hum = []
     for rat in mix_rat:
-        spec_hum.append(rat/(1 + rat))
+        spec_hum.append(rat / (1 + rat))
 
     # Integrate specific humidity
 
     pwv = 0.0
     for i in range(1, len(pressure) - 1):
-        pwv = pwv + 0.5*(spec_hum[i]+spec_hum[i-1])*(pressure[i-1]-pressure[i])
+        pwv = pwv + 0.5 * (spec_hum[i] + spec_hum[i - 1]) * (pressure[i - 1] -
+                                                             pressure[i])
 
     pwv = pwv / 0.098
     return pwv

--- a/act/retrievals/pwv_calc.py
+++ b/act/retrievals/pwv_calc.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+
+def calculate_precipitable_water(ds, temp_name='tdry', rh_name='rh',
+                                 pres_name='pres'):
+    """
+
+    Function to calculate precipitable water vapor from ARM sondewnpn b1 data.
+    Will first calculate saturation vapor pressure of all data using Arden-Buck
+    equations, then calculate specific humidity and integrate over all pressure
+    levels to give us a precipitable water value in centimeters.
+
+    ds : ACT object
+        Object as read in by the ACT netCDF reader.
+    temp_name : str
+        Name of temperature field to use. Defaults to 'tdry' for sondewnpn b1
+        level data.
+    rh_name : str
+        Name of relative humidity field to use. Defaults to 'rh' for sondewnpn
+        b1 level data.
+    pres_name : str
+        Name of atmospheric pressure field to use. Defaults to 'pres' for
+        sondewnpn b1 level data.
+
+    """
+    temp = ds[temp_name].values
+    rh = ds[rh_name].values
+    pres = ds[pres_name].values
+
+    # Get list of temperature values for saturation vapor pressure calc
+    temperature = []
+    for t in np.nditer(temp):
+        temperature.append(t)
+
+    # Apply Arden-Buck equation to get saturation vapor pressure
+    sat_vap_pres = []
+    for t in temperature:
+        # Over liquid water, above freezing
+        if t >= 0:
+            sat_vap_pres.append(0.61121 * np.exp((18.678-(t/234.5)) *
+                                (t/(257.14 + t))))
+        # Over ice, below freezing
+        else:
+            sat_vap_pres.append(0.61115 * np.exp((23.036 - (t/333.7)) *
+                                (t/(279.82 + t))))
+
+    # convert rh from % to decimal
+    rel_hum = []
+    for r in np.nditer(rh):
+        rel_hum.append(r/100.)
+
+    # get vapor pressure from rh and saturation vapor pressure
+    vap_pres = []
+    for i in range(0, len(sat_vap_pres)):
+        es = rel_hum[i] * sat_vap_pres[i]
+        vap_pres.append(es)
+
+    # Get list of pressure values for mixing ratio calc
+    pressure = []
+    for p in np.nditer(pres):
+        pressure.append(p)
+
+    # Mixing ratio calc
+
+    mix_rat = []
+    for i in range(0, len(vap_pres)):
+        mix_rat.append(0.622 * vap_pres[i] / (pressure[i] - vap_pres[i]))
+
+    # Specific humidity
+
+    spec_hum = []
+    for rat in mix_rat:
+        spec_hum.append(rat/(1 + rat))
+
+    # Integrate specific humidity
+
+    pwv = 0.0
+    for i in range(1, len(pressure) - 1):
+        pwv = pwv + 0.5*(spec_hum[i]+spec_hum[i-1])*(pressure[i-1]-pressure[i])
+
+    pwv = pwv / 0.098
+    return pwv

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -34,6 +34,7 @@ def test_generic_sobel_cbh():
     assert cbh[1000] == 555.
     ceil.close()
 
+
 def test_calculate_precipitable_water():
     sonde_ds = act.io.armfiles.read_netcdf(
         act.tests.sample_files.EXAMPLE_SONDE1)

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -38,6 +38,8 @@ def test_calculate_precipitable_water():
     sonde_ds = act.io.armfiles.read_netcdf(
         act.tests.sample_files.EXAMPLE_SONDE1)
     assert sonde_ds["tdry"].units == "C", "Temperature must be in Celsius"
+    assert sonde_ds["rh"].units == "%", "Relative Humidity must be a percentage"
+    assert sonde_ds["pres"].units == "hPa", "Pressure must be in hPa"
     pwv_data = act.retrievals.pwv_calc.calculate_precipitable_water(
         sonde_ds, temp_name='tdry', rh_name='rh', pres_name='pres')
     np.testing.assert_almost_equal(pwv_data, 0.8028, decimal=3)

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -33,3 +33,12 @@ def test_generic_sobel_cbh():
     assert cbh[500] == 615.
     assert cbh[1000] == 555.
     ceil.close()
+
+def test_calculate_precipitable_water():
+    sonde_ds = act.io.armfiles.read_netcdf(
+        act.tests.sample_files.EXAMPLE_SONDE1)
+    assert sonde_ds["tdry"].units == "C", "Temperature must be in Celsius"
+    pwv_data = act.retrievals.pwv_calc.calculate_precipitable_water(
+        sonde_ds, temp_name='tdry', rh_name='rh', pres_name='pres')
+    np.testing.assert_almost_equal(pwv_data, 0.8028, decimal=3)
+    sonde_ds.close()


### PR DESCRIPTION
For some of our DQ Office plots, we have been calculating precipitable water vapor values from sonde data, notably to compare with other instruments that measure pwv directly (see image). This was done in our IDL code as well, but I re-wrote it in python with more up-to-date equations. I think that this would be useful to have in ACT for anyone who is using ARM sonde data.
![nsacsphotC1 a1 pwv 232830 20190817](https://user-images.githubusercontent.com/46459286/64721795-ccee6500-d492-11e9-90db-4794b3505a21.png)
