### PR TITLE
ADD: Adding method to calculate active AOSPURGE times.

### DIFF
--- a/act/retrievals/__init__.py
+++ b/act/retrievals/__init__.py
@@ -14,9 +14,11 @@ This module contains various retrievals for ARM datsets.
     generic_sobel_cbh
     calculate_precipitable_water
     compute_winds_from_ppi
+    calculate_aospurge_times
 """
 
 from .stability_indices import calculate_stability_indicies
 from .cbh import generic_sobel_cbh
 from .pwv_calc import calculate_precipitable_water
 from .doppler_lidar import compute_winds_from_ppi
+from .purge_times import calculate_aospurge_times

--- a/act/retrievals/purge_times.py
+++ b/act/retrievals/purge_times.py
@@ -1,0 +1,107 @@
+import os
+
+import numpy as np
+import pandas as pd
+
+
+def calculate_aospurge_times(obj, threshold=None,
+                             txt_path=None):
+
+    """
+    Method to calculate times where the AOS purge system is active. It will
+    print out the start and end times and has the option to save those time
+    ranges to a .txt file. When there is a high amount of contamination in the
+    air, the AOS activates its purge system to flush the contaminated air from
+    the system. During this time, the AOS is not sampling ambient air and a DQR
+    should be written to include the time ranges when the purge system is
+    active.
+
+    Parameters
+    ----------
+    obj : ACT Object
+        Xarray Dataset as read by ACT where data are stored.
+    threshold : int
+        Minimum number of data points between separate start and end time
+        ranges. Will default to 1 minute.
+    txt_path : str
+        Path in which to save .txt files of start and end times. If set to none
+        will not save a text file.
+
+    Returns
+    -------
+    time_strings : list
+        List of tuples with the first element as the start time and the second
+        element as the end time.
+
+    Examples
+    --------
+    This example will return the times used for unit testing.
+
+    .. code-block:: python
+
+        import act
+
+        obj = act.io.armfiles.read_netcdf(
+            act.tests.sample_files.EXAMPLE_AOS_PURGE)
+
+        times = act.retrievals.purge_times.calculate_aospurge_times(obj)
+
+    """
+    # Get date from object
+    date = obj.attrs['file_dates'][0]
+
+    # Set default threshold value of 1 minute if None given.
+    if not threshold:
+        threshold = len(obj['time'].values) / 1440
+
+    # There is a variable in the aospurge data called stack_purge_state
+    # where a value of 1 indicates that the AOS is not sampling ambient
+    # air. Find the times where this is valid.
+    try:
+        stack = obj['stack_purge_state'].values
+    except ValueError:
+        return
+    # Getting time indices where purge is active
+    time_indices = np.where(stack == 1)[0]
+
+    # Calculate if there are multiple instances per day of purge
+    # Find instances in the array of time indices where difference > 1
+    time_diff = np.diff(time_indices)
+
+    # Split the array of time indices where blower is on for at least
+    # 60 seconds
+    splits = np.where(time_diff > threshold)
+    splits = splits[0] + 1
+
+    # If no indices where purge occurs then exit
+    if len(time_indices) == 0:
+        print('No purge occurs on ' + date)
+        return
+    else:
+        time_indices = np.split(time_indices, splits)
+
+    dt_times = []
+    for time in time_indices:
+        dt_times.append((obj['time'].values[time[0]],
+                        obj['time'].values[time[-1]]))
+
+    # Convert the datetimes to strings
+    time_strings = []
+    for st, et in dt_times:
+        start_time = pd.to_datetime(str(st)).strftime('%Y-%m-%d %H:%M:%S')
+        end_time = pd.to_datetime(str(et)).strftime('%Y-%m-%d %H:%M:%S')
+        time_strings.append((start_time, end_time))
+        # Print times to screen
+        print('AOSPURGE Begins at: ' + start_time, flush=True)
+        print('AOSPURGE Ends at: ' + end_time, flush=True)
+
+    if txt_path:
+        # Save to .txt file
+        if os.path.exists(txt_path) is False:
+            os.mkdir(txt_path)
+        with open(txt_path + '/dqrtimes_' + date + '.txt', 'w') as \
+                text_file:
+            for st, et in time_strings:
+                text_file.write('%s, ' % st)
+                text_file.write('%s \n' % et)
+    return time_strings

--- a/act/tests/__init__.py
+++ b/act/tests/__init__.py
@@ -22,4 +22,4 @@ from .sample_files import (EXAMPLE_SONDE1, EXAMPLE_LCL1,
                            EXAMPLE_CEIL_WILDCARD, EXAMPLE_ANL_CSV,
                            EXAMPLE_MPL_1SAMPLE, EXAMPLE_IRT25m20s,
                            EXAMPLE_MET_CONTOUR, EXAMPLE_NAV,
-                           EXAMPLE_AOSMET)
+                           EXAMPLE_AOSMET, EXAMPLE_AOSPURGE)

--- a/act/tests/sample_files.py
+++ b/act/tests/sample_files.py
@@ -19,6 +19,7 @@ be used for testing ACT.
     EXAMPLE_ANL_CSV
     EXAMPLE_VISST
     EXAMPLE_DLPPI
+    EXAMPLE_AOSPURGE
 """
 import os
 
@@ -46,3 +47,4 @@ EXAMPLE_NAV = os.path.join(DATA_PATH,
 EXAMPLE_AOSMET = os.path.join(DATA_PATH,
                               'maraosmetM1.a1.20180201.000000.nc')
 EXAMPLE_DLPPI = os.path.join(DATA_PATH, 'sgpdlppiC1.b1.20191015.120023.cdf')
+EXAMPLE_AOSPURGE = os.path.join(DATA_PATH, 'mosaospurgeM1.b1.20191016.000000.nc')

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -62,7 +62,7 @@ def test_doppler_lidar_winds():
 def test_calculate_aospurge_times():
     purge_ds = act.io.armfiles.read_netcdf(
         act.tests.sample_files.EXAMPLE_AOSPURGE)
-    purge_times = act.retrievals.purge_times.calculate_aospurge_times(filename=purge_ds)
+    purge_times = act.retrievals.purge_times.calculate_aospurge_times(purge_ds)
     assert purge_times == [('2019-10-16 00:08:04', '2019-10-16 00:10:16'), 
                            ('2019-10-16 00:29:27', '2019-10-16 00:44:35'), 
                            ('2019-10-16 00:51:28', '2019-10-16 00:53:51'), 

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -59,13 +59,14 @@ def test_doppler_lidar_winds():
     del dl_ds
     del result
 
+
 def test_calculate_aospurge_times():
     purge_ds = act.io.armfiles.read_netcdf(
         act.tests.sample_files.EXAMPLE_AOSPURGE)
     purge_times = act.retrievals.purge_times.calculate_aospurge_times(purge_ds)
-    assert purge_times == [('2019-10-16 00:08:04', '2019-10-16 00:10:16'), 
-                           ('2019-10-16 00:29:27', '2019-10-16 00:44:35'), 
-                           ('2019-10-16 00:51:28', '2019-10-16 00:53:51'), 
+    assert purge_times == [('2019-10-16 00:08:04', '2019-10-16 00:10:16'),
+                           ('2019-10-16 00:29:27', '2019-10-16 00:44:35'),
+                           ('2019-10-16 00:51:28', '2019-10-16 00:53:51'),
                            ('2019-10-16 00:59:39', '2019-10-16 01:00:10')]
     purge_ds.close()
     del purge_ds

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -58,3 +58,14 @@ def test_doppler_lidar_winds():
     dl_ds.close()
     del dl_ds
     del result
+
+def test_calculate_aospurge_times():
+    purge_ds = act.io.armfiles.read_netcdf(
+        act.tests.sample_files.EXAMPLE_AOSPURGE)
+    purge_times = act.retrievals.purge_times.calculate_aospurge_times(filename=purge_ds)
+    assert purge_times == [('2019-10-16 00:08:04', '2019-10-16 00:10:16'), 
+                           ('2019-10-16 00:29:27', '2019-10-16 00:44:35'), 
+                           ('2019-10-16 00:51:28', '2019-10-16 00:53:51'), 
+                           ('2019-10-16 00:59:39', '2019-10-16 01:00:10')]
+    purge_ds.close()
+    del purge_ds


### PR DESCRIPTION
When there is a high amount of contaminant in the AOS, the purge system will activate and flush the contaminated air. During this time the instrument is not sampling ambient air and those time ranges should be noted in a DQR. This script will take in an xarray Dataset of AOSPURGE data as read by act.io.armfiles.read_netcdf and return a list of time ranges when the purge system is active. It also contains an option to save the time ranges to a .txt file that can be read into the DQR submission tool.