### PR TITLE
Adding a Try to catch when file_dates not set in object.

### DIFF
--- a/act/plotting/TimeSeriesDisplay.py
+++ b/act/plotting/TimeSeriesDisplay.py
@@ -77,7 +77,10 @@ class TimeSeriesDisplay(Display):
             dsname = list(self._arm.keys())[0]
 
         # Get File Dates
-        file_dates = self._arm[dsname].attrs['file_dates']
+        try:
+            file_dates = self._arm[dsname].attrs['file_dates']
+        except KeyError:
+            file_dates = []
         if len(file_dates) == 0:
             sdate = dt_utils.numpy_to_arm_date(
                 self._arm[dsname].time.values[0])


### PR DESCRIPTION
I'm getting an error while plotting data not read in with the ACT reader. This try will allow data to be plotted with an Xarray Dataset read with Xarray only reader. I think this is the last bit of removing the act object variables.