### PR TITLE
DOC: Removing odd statement in the installation section.

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,5 +21,3 @@ You can build the Atmospheric data Community Toolkit from source and install it 
     $ cd ACT
     $ python setup.py install
 
-We soon plan to implement pip install and conda install features. 
-


### PR DESCRIPTION
I found an outdated statement in the documentation saying that we soon "plan on implementing pip and conda install" when we did that ages ago. I have removed the statement from the docs.