### PR TITLE
QC change

### DIFF
--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -45,26 +45,33 @@ class ARMStandardsFlag(Flag):
     """ The dataset does not have a datastream field. """
 
 
-def read_netcdf(filenames, concat_dim='time', return_None=False, **kwargs):
+def read_netcdf(filenames, concat_dim='time', return_None=False,
+                combine='by_coords', **kwargs):
     """
     Returns `xarray.Dataset` with stored data and metadata from a user-defined
     query of ARM-standard netCDF files from a single datastream.
 
     Parameters
     ----------
-    filenames: str or list
+    filenames : str or list
         Name of file(s) to read.
-    concat_dim: str
+    concat_dim : str
         Dimension to concatenate files along. Default value is 'time.'
-    return_none: bool, optional
+    return_none : bool, optional
         Catch IOError exception when file not found and return None.
         Default is False.
+    combine : str
+        String used by xarray.open_mfdataset() to determine how to combine
+        data files into one Dataset. See Xarray documentation for options.
+        'nested' will remove attributes that differ between files vs.
+        'by_coords' which will use the last file's attribute value.
+        Default is 'by_coords'.
     **kwargs: keywords
         Keywords to pass through to xarray.open_mfdataset().
 
     Returns
     -------
-    act_obj: Object (or None)
+    act_obj : Object (or None)
         ACT dataset (or None if no data file(s) found).
 
     Examples
@@ -84,12 +91,12 @@ def read_netcdf(filenames, concat_dim='time', return_None=False, **kwargs):
     file_times = []
     if return_None:
         try:
-            arm_ds = xr.open_mfdataset(filenames, combine='nested',
+            arm_ds = xr.open_mfdataset(filenames, combine=combine,
                                        concat_dim=concat_dim, **kwargs)
         except IOError:
             return None
     else:
-        arm_ds = xr.open_mfdataset(filenames, combine='nested',
+        arm_ds = xr.open_mfdataset(filenames, combine=combine,
                                    concat_dim=concat_dim, **kwargs)
 
     # Check if time variable is not in the netCDF file or if the time values are not
@@ -117,7 +124,7 @@ def read_netcdf(filenames, concat_dim='time', return_None=False, **kwargs):
 
     # Get file dates and times that were read in to the object
     filenames.sort()
-    for n, f in enumerate(filenames):
+    for f in filenames:
         file_dates.append(f.split('.')[-3])
         file_times.append(f.split('.')[-2])
 

--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -172,7 +172,7 @@ def test_xsection_plot():
 @pytest.mark.mpl_image_compare(tolerance=30)
 def test_xsection_plot_map():
     radar_ds = arm.read_netcdf(
-        sample_files.EXAMPLE_VISST)
+        sample_files.EXAMPLE_VISST, combine='nested')
     xsection = XSectionDisplay(radar_ds, figsize=(15, 8))
     xsection.plot_xsection_map(None, 'ir_temperature', vmin=220, vmax=300, cmap='Greys',
                                x='longitude', y='latitude', isel_kwargs={'time': 0})


### PR DESCRIPTION
Austin discovered an issue with QC when the location of QC bit description changed from global to variable attributes. Turns out that open_mfdataset() with combine='nested' will just not read any attribute that changes between read data files. This results in a problem parsing the attributes for determining QC information. After looking into options I discovered that setting combine='by_coords' will read the attributes and keep the ones set by last data file. This allows us to get something to work with and then fix it once read in. This should also do some more magic to get the ordering of values in a coordinate to be monotonic. I think it will be better overall. I initially put in these keywords to stop xarray from printing a warning.

I had to modify the one test code to use 'nested' when it had a dimension not in the file 'time'. To enable users to set all the values all options sent to open_mfdataset() are now setable with the read_netcdf() call.

Also found use of enumerate() in a for loop where it was not being used.