### PR TITLE
A few changes to fix how xarray reads the time units string. 

### DIFF
--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -15,9 +15,6 @@ import numpy as np
 import urllib
 import json
 from enum import Flag, auto
-#from cftime._cftime import (DatetimeGregorian, DatetimeProlepticGregorian,
-#                            DatetimeJulian)
-#cftime_classes = (DatetimeGregorian, DatetimeProlepticGregorian, DatetimeJulian)
 
 
 class ARMStandardsFlag(Flag):
@@ -148,7 +145,6 @@ def read_netcdf(filenames, concat_dim='time', return_None=False,
     desired_time_precision = 'datetime64[us]'
     if (cftime_to_datetime64 and 'time' in arm_ds.dims and
             'time' in arm_ds.coords and
-#            isinstance(arm_ds['time'].values[0], cftime_classes)):
             type(arm_ds['time'].values[0]).__module__.startswith('cftime.')):
         # If we just convert time to datetime64 the group, sel, and other Xarray
         # methods will not work correctly because time is not indexed. Need to
@@ -191,7 +187,7 @@ def read_netcdf(filenames, concat_dim='time', return_None=False,
     if (cftime_to_datetime64 and 'time' in arm_ds.dims and
             not np.issubdtype(arm_ds['time'].values.dtype, np.datetime64) and
             'base_time' in arm_ds.data_vars and
-            not type(time[0]).__module__.startswith('cftime.')):
+            not type(arm_ds['time'].values[0]).__module__.startswith('cftime.')):
         time = (arm_ds['base_time'].values +
                 arm_ds['time'].values).astype(desired_time_precision)
 

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -75,9 +75,9 @@ def read_netcdf(filenames, concat_dim='time', return_None=False,
         don't want to convert the times in xarray dataset from cftime to numpy datetime64.
     cftime_to_datetime64 : boolean
         If time is stored as cftime in xarray dataset convert to numpy datetime64. If time
-        precision requried is sub millisecond set decode_times=False,
-        and drop_variables=['time'], but leave cftime_to_datetime64=True. This will force
-        it to use base_time and time_offset to set time.
+        precision requried is sub millisecond set decode_times=False but leave
+        cftime_to_datetime64=True. This will force it to use base_time and time_offset
+        to set time.
     **kwargs: keywords
         Keywords to pass through to xarray.open_mfdataset().
 

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -92,7 +92,7 @@ def read_netcdf(filenames, concat_dim='time', return_None=False,
 
     .. code-block:: python
 
-        import acta
+        import act
 
         the_ds, the_flag = act.io.armfiles.read_netcdf(
             act.tests.sample_files.EXAMPLE_SONDE_WILDCARD)
@@ -275,6 +275,7 @@ def create_obj_from_arm_dod(proc, set_dims, version='', fill_value=-9999.,
         are dimensioned to the main dimension.  i.e. a lat/lon is set to have
         a dimension of time.  This is a way to set it up similarly.
 
+
     Returns
     -------
     obj: xarray Dataset
@@ -283,6 +284,7 @@ def create_obj_from_arm_dod(proc, set_dims, version='', fill_value=-9999.,
     Examples
     --------
     .. code-block:: python
+
         dims = {'time': 1440, 'drop_diameter': 50}
         obj = act.io.armfiles.create_obj_from_arm_dod('vdis.b1', dims, version='1.2', scalar_fill_dim='time')
 

--- a/act/io/clean.py
+++ b/act/io/clean.py
@@ -24,15 +24,15 @@ class CleanDataset(object):
 
         # Will need to find all historical cases and add to list
         qc_dict = {'description':
-                   ["See global attributes for individual.+bit descriptions.",
-                    "This field contains bit packed integer values, where "
-                    "each bit represents a QC test on the data. Non-zero "
-                    "bits indicate the QC condition given in the "
-                    "description for those bits; a value of 0 "
-                    "\(no bits set\) indicates "
-                    "the data has not failed any QC tests.",
-                    "This field contains bit packed values which should be "
-                    "interpreted as listed..+"
+                   [r"See global attributes for individual.+bit descriptions.",
+                    r"This field contains bit packed integer values, where "
+                    r"each bit represents a QC test on the data. Non-zero "
+                    r"bits indicate the QC condition given in the "
+                    r"description for those bits; a value of 0 "
+                    r"(no bits set) indicates "
+                    r"the data has not failed any QC tests.",
+                    r"This field contains bit packed values which should be "
+                    r"interpreted as listed..+"
                     ]
                    }
 


### PR DESCRIPTION
Also updated the error handling for FileNotFoundError.

This all came about after we updated combine='by_coords'. I still think this is the correct method but we discovered that the way Xarray reads the units string with time is not correct. It does not handle the timezone offset part at the end of the units string. This was causing it to not set the time correctly, but date was correct. To fix this we are setting use_cftime=True to force it to use the cftime library to fix the units string reading part. The issue is that this will read the data in as cftime and leave it that way in the returned object. The second part of this is to convert the time back to expected numpy datetime64 values.

I also updated the way we handle the errors so we can fine tune the error handling and use the error string to parse specific errors and try to handle them. If we get a very specific error we will change combine = 'nested' and try again. If it still fails or fails for a different ValueError reason will just throw that error right away.

A lot of changes but all for the better.